### PR TITLE
Use rust byte string

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,42 +35,60 @@ Performance and memory safety were two important factors while designing _mail-p
 ## Usage Example
 
 ```rust
-    let input = concat!(
-        "From: Art Vandelay <art@vandelay.com> (Vandelay Industries)\n",
-        "To: \"Colleagues\": \"James Smythe\" <james@vandelay.com>; Friends:\n",
-        "    jane@example.com, =?UTF-8?Q?John_Sm=C3=AEth?= <john@example.com>;\n",
-        "Date: Sat, 20 Nov 2021 14:22:01 -0800\n",
-        "Subject: Why not both importing AND exporting? =?utf-8?b?4pi6?=\n",
-        "Content-Type: multipart/mixed; boundary=\"festivus\";\n\n",
-        "--festivus\n",
-        "Content-Type: text/html; charset=\"us-ascii\"\n",
-        "Content-Transfer-Encoding: base64\n\n",
-        "PGh0bWw+PHA+SSB3YXMgdGhpbmtpbmcgYWJvdXQgcXVpdHRpbmcgdGhlICZsZHF1bztle\n",
-        "HBvcnRpbmcmcmRxdW87IHRvIGZvY3VzIGp1c3Qgb24gdGhlICZsZHF1bztpbXBvcnRpbm\n",
-        "cmcmRxdW87LDwvcD48cD5idXQgdGhlbiBJIHRob3VnaHQsIHdoeSBub3QgZG8gYm90aD8\n",
-        "gJiN4MjYzQTs8L3A+PC9odG1sPg==\n",
-        "--festivus\n",
-        "Content-Type: message/rfc822\n\n",
-        "From: \"Cosmo Kramer\" <kramer@kramerica.com>\n",
-        "Subject: Exporting my book about coffee tables\n",
-        "Content-Type: multipart/mixed; boundary=\"giddyup\";\n\n",
-        "--giddyup\n",
-        "Content-Type: text/plain; charset=\"utf-16\"\n",
-        "Content-Transfer-Encoding: quoted-printable\n\n",
-        "=FF=FE=0C!5=D8\"=DD5=D8)=DD5=D8-=DD =005=D8*=DD5=D8\"=DD =005=D8\"=\n",
-        "=DD5=D85=DD5=D8-=DD5=D8,=DD5=D8/=DD5=D81=DD =005=D8*=DD5=D86=DD =\n",
-        "=005=D8=1F=DD5=D8,=DD5=D8,=DD5=D8(=DD =005=D8-=DD5=D8)=DD5=D8\"=\n",
-        "=DD5=D8=1E=DD5=D80=DD5=D8\"=DD!=00\n",
-        "--giddyup\n",
-        "Content-Type: image/gif; name*1=\"about \"; name*0=\"Book \";\n",
-        "              name*2*=utf-8''%e2%98%95 tables.gif\n",
-        "Content-Transfer-Encoding: Base64\n",
-        "Content-Disposition: attachment\n\n",
-        "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7\n",
-        "--giddyup--\n",
-        "--festivus--\n",
-    )
-    .as_bytes();
+/*
+ * Copyright Stalwart Labs, Minter Ltd. See the COPYING
+ * file at the top-level directory of this distribution.
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+ */
+
+use mail_parser::*;
+
+fn main() {
+    let input = br#"From: Art Vandelay <art@vandelay.com> (Vandelay Industries)
+To: "Colleagues": "James Smythe" <james@vandelay.com>; Friends:
+    jane@example.com, =?UTF-8?Q?John_Sm=C3=AEth?= <john@example.com>;
+Date: Sat, 20 Nov 2021 14:22:01 -0800
+Subject: Why not both importing AND exporting? =?utf-8?b?4pi6?=
+Content-Type: multipart/mixed; boundary="festivus";
+
+--festivus
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: base64
+
+PGh0bWw+PHA+SSB3YXMgdGhpbmtpbmcgYWJvdXQgcXVpdHRpbmcgdGhlICZsZHF1bztle
+HBvcnRpbmcmcmRxdW87IHRvIGZvY3VzIGp1c3Qgb24gdGhlICZsZHF1bztpbXBvcnRpbm
+cmcmRxdW87LDwvcD48cD5idXQgdGhlbiBJIHRob3VnaHQsIHdoeSBub3QgZG8gYm90aD8
+gJiN4MjYzQTs8L3A+PC9odG1sPg==
+--festivus
+Content-Type: message/rfc822
+
+From: "Cosmo Kramer" <kramer@kramerica.com>
+Subject: Exporting my book about coffee tables
+Content-Type: multipart/mixed; boundary="giddyup";
+
+--giddyup
+Content-Type: text/plain; charset="utf-16"
+Content-Transfer-Encoding: quoted-printable
+
+=FF=FE=0C!5=D8"=DD5=D8)=DD5=D8-=DD =005=D8*=DD5=D8"=DD =005=D8"=
+=DD5=D85=DD5=D8-=DD5=D8,=DD5=D8/=DD5=D81=DD =005=D8*=DD5=D86=DD =
+=005=D8=1F=DD5=D8,=DD5=D8,=DD5=D8(=DD =005=D8-=DD5=D8)=DD5=D8"=
+=DD5=D8=1E=DD5=D80=DD5=D8"=DD!=00
+--giddyup
+Content-Type: image/gif; name*1="about "; name*0="Book ";
+              name*2*=utf-8''%e2%98%95 tables.gif
+Content-Transfer-Encoding: Base64
+Content-Disposition: attachment
+
+R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
+--giddyup--
+--festivus--
+"#;
 
     let message = Message::parse(input).unwrap();
 
@@ -119,7 +137,7 @@ Performance and memory safety were two important factors while designing _mail-p
         "Why not both importing AND exporting? ☺"
     );
 
-    // HTML and text body parts are returned conforming to RFC8621, Section 4.1.4 
+    // HTML and text body parts are returned conforming to RFC8621, Section 4.1.4
     assert_eq!(
         message.get_html_body(0).unwrap().to_string(),
         concat!(
@@ -179,6 +197,7 @@ Performance and memory safety were two important factors while designing _mail-p
     // Integrates with Serde
     println!("{}", serde_json::to_string_pretty(&message).unwrap());
     println!("{}", serde_yaml::to_string(&message).unwrap());
+}
 ```
 
 ## Testing, Fuzzing & Benchmarking

--- a/examples/email_to_json_and_yaml.rs
+++ b/examples/email_to_json_and_yaml.rs
@@ -12,42 +12,46 @@
 use mail_parser::*;
 
 fn main() {
-    let input = concat!(
-        "From: Art Vandelay <art@vandelay.com> (Vandelay Industries)\n",
-        "To: \"Colleagues\": \"James Smythe\" <james@vandelay.com>; Friends:\n",
-        "    jane@example.com, =?UTF-8?Q?John_Sm=C3=AEth?= <john@example.com>;\n",
-        "Date: Sat, 20 Nov 2021 14:22:01 -0800\n",
-        "Subject: Why not both importing AND exporting? =?utf-8?b?4pi6?=\n",
-        "Content-Type: multipart/mixed; boundary=\"festivus\";\n\n",
-        "--festivus\n",
-        "Content-Type: text/html; charset=\"us-ascii\"\n",
-        "Content-Transfer-Encoding: base64\n\n",
-        "PGh0bWw+PHA+SSB3YXMgdGhpbmtpbmcgYWJvdXQgcXVpdHRpbmcgdGhlICZsZHF1bztle\n",
-        "HBvcnRpbmcmcmRxdW87IHRvIGZvY3VzIGp1c3Qgb24gdGhlICZsZHF1bztpbXBvcnRpbm\n",
-        "cmcmRxdW87LDwvcD48cD5idXQgdGhlbiBJIHRob3VnaHQsIHdoeSBub3QgZG8gYm90aD8\n",
-        "gJiN4MjYzQTs8L3A+PC9odG1sPg==\n",
-        "--festivus\n",
-        "Content-Type: message/rfc822\n\n",
-        "From: \"Cosmo Kramer\" <kramer@kramerica.com>\n",
-        "Subject: Exporting my book about coffee tables\n",
-        "Content-Type: multipart/mixed; boundary=\"giddyup\";\n\n",
-        "--giddyup\n",
-        "Content-Type: text/plain; charset=\"utf-16\"\n",
-        "Content-Transfer-Encoding: quoted-printable\n\n",
-        "=FF=FE=0C!5=D8\"=DD5=D8)=DD5=D8-=DD =005=D8*=DD5=D8\"=DD =005=D8\"=\n",
-        "=DD5=D85=DD5=D8-=DD5=D8,=DD5=D8/=DD5=D81=DD =005=D8*=DD5=D86=DD =\n",
-        "=005=D8=1F=DD5=D8,=DD5=D8,=DD5=D8(=DD =005=D8-=DD5=D8)=DD5=D8\"=\n",
-        "=DD5=D8=1E=DD5=D80=DD5=D8\"=DD!=00\n",
-        "--giddyup\n",
-        "Content-Type: image/gif; name*1=\"about \"; name*0=\"Book \";\n",
-        "              name*2*=utf-8''%e2%98%95 tables.gif\n",
-        "Content-Transfer-Encoding: Base64\n",
-        "Content-Disposition: attachment\n\n",
-        "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7\n",
-        "--giddyup--\n",
-        "--festivus--\n",
-    )
-    .as_bytes();
+    let input = br#"From: Art Vandelay <art@vandelay.com> (Vandelay Industries)
+To: "Colleagues": "James Smythe" <james@vandelay.com>; Friends:
+    jane@example.com, =?UTF-8?Q?John_Sm=C3=AEth?= <john@example.com>;
+Date: Sat, 20 Nov 2021 14:22:01 -0800
+Subject: Why not both importing AND exporting? =?utf-8?b?4pi6?=
+Content-Type: multipart/mixed; boundary="festivus";
+
+--festivus
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: base64
+
+PGh0bWw+PHA+SSB3YXMgdGhpbmtpbmcgYWJvdXQgcXVpdHRpbmcgdGhlICZsZHF1bztle
+HBvcnRpbmcmcmRxdW87IHRvIGZvY3VzIGp1c3Qgb24gdGhlICZsZHF1bztpbXBvcnRpbm
+cmcmRxdW87LDwvcD48cD5idXQgdGhlbiBJIHRob3VnaHQsIHdoeSBub3QgZG8gYm90aD8
+gJiN4MjYzQTs8L3A+PC9odG1sPg==
+--festivus
+Content-Type: message/rfc822
+
+From: "Cosmo Kramer" <kramer@kramerica.com>
+Subject: Exporting my book about coffee tables
+Content-Type: multipart/mixed; boundary="giddyup";
+
+--giddyup
+Content-Type: text/plain; charset="utf-16"
+Content-Transfer-Encoding: quoted-printable
+
+=FF=FE=0C!5=D8"=DD5=D8)=DD5=D8-=DD =005=D8*=DD5=D8"=DD =005=D8"=
+=DD5=D85=DD5=D8-=DD5=D8,=DD5=D8/=DD5=D81=DD =005=D8*=DD5=D86=DD =
+=005=D8=1F=DD5=D8,=DD5=D8,=DD5=D8(=DD =005=D8-=DD5=D8)=DD5=D8"=
+=DD5=D8=1E=DD5=D80=DD5=D8"=DD!=00
+--giddyup
+Content-Type: image/gif; name*1="about "; name*0="Book ";
+              name*2*=utf-8''%e2%98%95 tables.gif
+Content-Transfer-Encoding: Base64
+Content-Disposition: attachment
+
+R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
+--giddyup--
+--festivus--
+"#;
 
     let message = Message::parse(input).unwrap();
 


### PR DESCRIPTION
Using rust  r#"multi line"# string,
and putting a 'b' for that string makes it bytes.

So no more
  let input = concat!(
      "line\n",
      "next line\n",
      "escaped quote \"\n",
   )
   .as_bytes();
but
  let input = br#"line
next line
escaped quote "
"#;

The examples/email_json_and_yaml.rs without the many \"  \n
is also inserted the README.md which removed trailing white space
and restored a lost  }