### PR TITLE
Change date is_valid check to inclusive range

### DIFF
--- a/src/parsers/fields/date.rs
+++ b/src/parsers/fields/date.rs
@@ -32,14 +32,14 @@ impl DateTime {
 
     /// Returns true if the date is valid
     pub fn is_valid(&self) -> bool {
-        (0..23).contains(&self.tz_hour)
-            && (0..59).contains(&self.tz_minute)
-            && (1970..2500).contains(&self.year)
-            && (1..12).contains(&self.month)
-            && (1..31).contains(&self.day)
-            && (0..23).contains(&self.hour)
-            && (0..59).contains(&self.minute)
-            && (0..59).contains(&self.second)
+        (0..=23).contains(&self.tz_hour)
+            && (0..=59).contains(&self.tz_minute)
+            && (1970..=2500).contains(&self.year)
+            && (1..=12).contains(&self.month)
+            && (1..=31).contains(&self.day)
+            && (0..=23).contains(&self.hour)
+            && (0..=59).contains(&self.minute)
+            && (0..=59).contains(&self.second)
     }
 
     /// Returns the numbers of seconds since 1970-01-01T00:00:00Z (Unix epoch)

--- a/src/parsers/fields/date.rs
+++ b/src/parsers/fields/date.rs
@@ -34,7 +34,6 @@ impl DateTime {
     pub fn is_valid(&self) -> bool {
         (0..=23).contains(&self.tz_hour)
             && (0..=59).contains(&self.tz_minute)
-            && (1970..=2500).contains(&self.year)
             && (1..=12).contains(&self.month)
             && (1..=31).contains(&self.day)
             && (0..=23).contains(&self.hour)


### PR DESCRIPTION
I noticed that dates with e.g. minutes 59 were failing the parser here.

I also remove the year check, as years before 1970 and after 2500 are still valid dates

More broadly, I question whether this check should be here. I would think it makes more sense to put it on the initializer for DateTime, not on converting it to unix time. Otherwise you could print invalid iso8601 dates, etc. Let me know what you think.