### PR TITLE
ISO 8601 Zero-offset timezones should always be positive

### DIFF
--- a/src/parsers/fields/date.rs
+++ b/src/parsers/fields/date.rs
@@ -16,6 +16,11 @@ use crate::{parsers::message::MessageStream, DateTime, HeaderValue};
 impl DateTime {
     /// Returns an ISO-8601 representation of the parsed RFC5322 datetime field
     pub fn to_iso8601(&self) -> String {
+        let tz_sign = if self.tz_before_gmt && (self.tz_hour > 0 || self.tz_minute > 0) {
+            "-"
+        } else {
+            "+"
+        };
         format!(
             "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}{}{:02}:{:02}",
             self.year,
@@ -24,7 +29,7 @@ impl DateTime {
             self.hour,
             self.minute,
             self.second,
-            if self.tz_before_gmt { "-" } else { "+" },
+            tz_sign,
             self.tz_hour,
             self.tz_minute
         )


### PR DESCRIPTION
ISO 8601 forbids negative zero-offsets (`-00:00`) even though it is allowed by RFC 5322