### PR TITLE
derive Clone for DateTime

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -779,7 +779,7 @@ pub struct ContentType<'x> {
 }
 
 /// An RFC5322 datetime.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct DateTime {
     pub year: u32,


### PR DESCRIPTION
This might be useful for `struct`s that want to store a `DateTime` while also deriving `Clone` themself.