### PR TITLE
Add offset_last_part to Message

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,7 @@ pub struct Message<'x> {
 
     pub offset_header: usize,
     pub offset_body: usize,
+    pub offset_last_part: usize,
     pub offset_end: usize,
     #[cfg_attr(feature = "serde_support", serde(skip))]
     pub raw_message: Cow<'x, [u8]>,

--- a/src/parsers/message.rs
+++ b/src/parsers/message.rs
@@ -399,6 +399,11 @@ impl<'x> Message<'x> {
                 stream.pos += bytes_read;
             }
 
+            message.offset_last_part = match bytes {
+                DecodeResult::Borrowed((_, pos)) => pos,
+                _ => stream.pos,
+            };
+
             if mime_type != MimeType::Message {
                 let is_inline = is_inline
                     && header


### PR DESCRIPTION
## Issue

When I use `mail-parser` to build an IMAP server, I got invalid results when I need to compute the length and the number of lines of a child message based on mail-parser `Message.raw_message` field.

## Explanation

Both `Message.raw_message` and `Message.offset_end` points past the end of the child message.
They include the empty line AND part of the parent MIME delimiter that signals the end of the MIME Part (and thus are not part of it). Of course `Parts` in `Message.parts` do not include these data, but at the same time, they can't be used to compute the total number of lines OR the full size in bytes of the child message.

## My solution

I propose to add another field to the `Message` structure named `Message.offset_last_part`. Thanks to this field,
we can compute the size of a child Message with: `len = Message.offset_last_part - Message.offset_header`, and the number of lines with ` Cursor::new(&child.raw_message[..len]).lines().count()`.

At the same time, it does not break backward compatibility as it does not change existing fields.

## Example

I am implementing an IMAP server and use `mail-parser` to parse emails and then build IMAP Response to requests like:

```
A10 FETCH 1:1 (BODY)
```

Which gives the structure of an email, the following example is taken from Dovecot (new lines were added for readability):

```lisp
(body 
  (("text" "plain" ("charset" "us-ascii") nil nil "7bit" 9 1)
   ("message" "rfc822" nil nil nil "7bit" 129 
     (nil "welcome to aerogramme!!" 
       (("garage team" nil "garagehq" "deuxfleurs.fr")) 
       (("garage team" nil "garagehq" "deuxfleurs.fr")) 
       (("garage team" nil "garagehq" "deuxfleurs.fr")) 
       nil nil nil nil nil)
     ("text" "plain" ("charset" "us-ascii") nil nil "7bit" 49 1) 
     4) 
  "mixed"))
```

Some important information are that Dovecot sees:
  - 129 bytes for the child email
  - 4 lines

The original email looks like this (I replace the @ by a dot to prevent spam):

```eml
From: Garage team <garagehq.deuxfleurs.fr>
Content-Type: multipart/mixed; boundary="delim";
Subject: Welcome to Aerogramme!!

--delim
Content-Type: text/plain; charset="us-ascii"

Hello 1

--delim
Content-Type: message/rfc822

From: Garage team <garagehq.deuxfleurs.fr>
Subject: Welcome to Aerogramme!!

This is just a test email, feel free to ignore.

--delim--
```

If I try to parse it as follow:

```rust
use mail_parser::*;
use std::fs;
use std::io::{Cursor,BufRead};
fn main() {
    let msg = fs::read("example_email.eml").unwrap();
    let parsed = Message::parse(&msg).unwrap();
    let child = parsed.parts[1].unwrap_message();
    println!("(before patch) len: {}", child.raw_message.len());
    println!("(before patch) lines: {}", Cursor::new(child.raw_message.as_ref()).lines().count());

    let new_len = child.offset_last_part - child.offset_header;
    println!("(after patch) len: {}", new_len);
    println!("(after patch) lines: {}", Cursor::new(&child.raw_message[..new_len]).lines().count());
}
```

I get:

```
(before patch) len: 138
(before patch) lines: 6
(after patch) len: 129
(after patch) lines: 4
```

We see that only our "after patch" lines are correct and match Dovecot structure result.

For information, this is what `child.raw_message` contains:

```eml
From: Garage team <garagehq.deuxfleurs.fr>
Subject: Welcome to Aerogramme!!

This is just a test email, feel free to ignore.

--delim
```

