### PR TITLE
WIP: Add information to use mail-parser in an IMAP server

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,6 +323,7 @@ pub struct Part<'x, T> {
     pub headers_raw: RawHeaders<'x>,
     pub is_encoding_problem: bool,
     pub body: T,
+    pub body_raw: Cow<'x, [u8]>,
 }
 
 impl<'x, T> Part<'x, T> {
@@ -330,12 +331,14 @@ impl<'x, T> Part<'x, T> {
         headers_rfc: RfcHeaders<'x>,
         headers_raw: RawHeaders<'x>,
         body: T,
+        body_raw: Cow<'x, [u8]>,
         is_encoding_problem: bool,
     ) -> Self {
         Self {
             headers_rfc,
             headers_raw,
             body,
+            body_raw,
             is_encoding_problem,
         }
     }


### PR DESCRIPTION
It seems that my previous patch was not totally correct (for example, it does not work with DecodeResult::Borrowed).
So I have rewritten it to to use only `stream.pos` and `state.mime_boundary.as_ref()`.
But I am not totally satisfied yet: the specific problem is when there is a RFC822 message contained in an RFC5322 message, mail-parser wrongly include the MIME delimiter from the parent in the child, RFC822 email. I want to fix it and validate all this logic on your test emails.

Retrospectively, I am not sure that `offset_last_part` is really needed, but having a `body_raw` in Part is required: an IMAP server must not decode content and return its raw size, not its decoded size.

Also, I am a bit worried with my new fields: it might break your tests, so we need to check that and maybe update them.
I will not be available in the next weeks but hope to finish this work until the end of the summer.

In the end, I think you should take into account this information if you want to make a release during this time: my previous PR might not be that great. If you really need to make a release, I would recommend that you rollback it.

Sorry, I thought that the problem might be easier to address.