### PR TITLE
Microbenchmarks for ludicrous mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ categories = ["email", "parser-implementations"]
 readme = "README.md"
 resolver = "2"
 
+[[bench]]
+name = "bench"
+harness = false
+
 [dependencies]
 encoding_rs = { version="0.8", optional=true }
 serde = { version = "1.0", features = ["derive"], optional=true }
@@ -22,12 +26,11 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 bincode = "1.3.3"
 chrono = "0.4"
+criterion = "0.5"
+rand = "0.8.5"
 
 [features]
 default = ["full_encoding"]
 full_encoding = ["encoding_rs"]
 serde_support = ["serde"]
 ludicrous_mode = []
-
-[profile.bench]
-debug = true

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,8 @@
+use criterion::{criterion_group, criterion_main};
+
+mod ludicrous;
+mod parse;
+
+// run benchmarks with: cargo bench --bench bench
+criterion_group!(benches, ludicrous::ludicrous_bench, parse::parse_bench);
+criterion_main!(benches);

--- a/benches/ludicrous.rs
+++ b/benches/ludicrous.rs
@@ -1,0 +1,50 @@
+use criterion::{BatchSize, Bencher, black_box, Criterion};
+use rand::Rng;
+use rand::rngs::OsRng;
+
+
+static HDR_HASH: &[u8] = &[
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+    73, 0, 20, 5, 0, 0, 25, 0, 5, 20, 73, 25, 25, 30, 10, 10, 5, 73, 0, 0, 15, 73, 73, 73, 73, 20,
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+    73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73, 73,
+];
+
+/// Confirm whether ludicrous mode makes an impact.
+pub fn ludicrous_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("ludicrous");
+    group.sample_size(10);
+    group.bench_function("with", bench_with);
+    group.bench_function("without", bench_without);
+}
+
+/// With unsafe ludicrous mode code.
+fn bench_with(b: &mut Bencher) {
+    b.iter_batched(|| {
+        OsRng.gen()
+    }, |rand: u8| {
+        black_box({
+            unsafe {
+                *HDR_HASH.get_unchecked(rand as usize)
+            }
+        })
+    }, BatchSize::SmallInput);
+}
+
+/// Fully safe code.
+fn bench_without(b: &mut Bencher) {
+    b.iter_batched(|| {
+        OsRng.gen()
+    }, |rand: u8| {
+        black_box({
+            HDR_HASH[rand as usize]
+        })
+    }, BatchSize::SmallInput);
+}

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,0 +1,58 @@
+use criterion::{BatchSize, Bencher, black_box, Criterion};
+use mail_parser::MessageParser;
+
+const INPUT: &[u8] = br#"From: Art Vandelay <art@vandelay.com> (Vandelay Industries)
+To: "Colleagues": "James Smythe" <james@vandelay.com>; Friends:
+    jane@example.com, =?UTF-8?Q?John_Sm=C3=AEth?= <john@example.com>;
+Date: Sat, 20 Nov 2021 14:22:01 -0800
+Subject: Why not both importing AND exporting? =?utf-8?b?4pi6?=
+Content-Type: multipart/mixed; boundary="festivus";
+
+--festivus
+Content-Type: text/html; charset="us-ascii"
+Content-Transfer-Encoding: base64
+
+PGh0bWw+PHA+SSB3YXMgdGhpbmtpbmcgYWJvdXQgcXVpdHRpbmcgdGhlICZsZHF1bztle
+HBvcnRpbmcmcmRxdW87IHRvIGZvY3VzIGp1c3Qgb24gdGhlICZsZHF1bztpbXBvcnRpbm
+cmcmRxdW87LDwvcD48cD5idXQgdGhlbiBJIHRob3VnaHQsIHdoeSBub3QgZG8gYm90aD8
+gJiN4MjYzQTs8L3A+PC9odG1sPg==
+--festivus
+Content-Type: message/rfc822
+
+From: "Cosmo Kramer" <kramer@kramerica.com>
+Subject: Exporting my book about coffee tables
+Content-Type: multipart/mixed; boundary="giddyup";
+
+--giddyup
+Content-Type: text/plain; charset="utf-16"
+Content-Transfer-Encoding: quoted-printable
+
+=FF=FE=0C!5=D8"=DD5=D8)=DD5=D8-=DD =005=D8*=DD5=D8"=DD =005=D8"=
+=DD5=D85=DD5=D8-=DD5=D8,=DD5=D8/=DD5=D81=DD =005=D8*=DD5=D86=DD =
+=005=D8=1F=DD5=D8,=DD5=D8,=DD5=D8(=DD =005=D8-=DD5=D8)=DD5=D8"=
+=DD5=D8=1E=DD5=D80=DD5=D8"=DD!=00
+--giddyup
+Content-Type: image/gif; name*1="about "; name*0="Book ";
+              name*2*=utf-8''%e2%98%95 tables.gif
+Content-Transfer-Encoding: Base64
+Content-Disposition: attachment
+
+R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
+--giddyup--
+--festivus--
+"#;
+
+
+pub fn parse_bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("parse");
+    group.sample_size(10);
+    group.bench_function("constant", bench_with);
+}
+
+fn bench_with(b: &mut Bencher) {
+    b.iter(|| {
+        black_box({
+            MessageParser::default().parse(INPUT).unwrap()
+        })
+    });
+}


### PR DESCRIPTION
Hey,

I believe ludicrous mode to be a bit superfluous, as bounds checking appears to get optimised out by the compiler for u8 with 256 len arrays, judging by these microbenchmarks. 

I'd like to reduce unsafe code used by mail-server, and believe this would be a quick win? If you agree, I'm happy to make a followup MR removing ludicrous mode?

Cheers,
Liam