### PR TITLE
fix: `MessagePart::len` not returning right value on nested messages.

### DIFF
--- a/src/core/body.rs
+++ b/src/core/body.rs
@@ -17,7 +17,7 @@ impl<'x> PartType<'x> {
         match self {
             PartType::Text(v) | PartType::Html(v) => v.len(),
             PartType::Binary(v) | PartType::InlineBinary(v) => v.len(),
-            PartType::Message(v) => v.raw_message.len(),
+            PartType::Message(v) => v.raw_message().len(),
             PartType::Multipart(_) => 0,
         }
     }

--- a/src/core/header.rs
+++ b/src/core/header.rs
@@ -591,7 +591,7 @@ impl<'x> MessagePart<'x> {
         match &self.body {
             PartType::Text(text) | PartType::Html(text) => text.as_bytes(),
             PartType::Binary(bin) | PartType::InlineBinary(bin) => bin.as_ref(),
-            PartType::Message(message) => message.raw_message.as_ref(),
+            PartType::Message(message) => message.raw_message().as_ref(),
             PartType::Multipart(_) => b"",
         }
     }
@@ -603,7 +603,7 @@ impl<'x> MessagePart<'x> {
             PartType::Binary(bin) | PartType::InlineBinary(bin) => {
                 std::str::from_utf8(bin.as_ref()).ok()
             }
-            PartType::Message(message) => std::str::from_utf8(message.raw_message.as_ref()).ok(),
+            PartType::Message(message) => std::str::from_utf8(message.raw_message().as_ref()).ok(),
             PartType::Multipart(_) => None,
         }
     }
@@ -631,7 +631,7 @@ impl<'x> MessagePart<'x> {
         match &self.body {
             PartType::Text(text) | PartType::Html(text) => text.len(),
             PartType::Binary(bin) | PartType::InlineBinary(bin) => bin.len(),
-            PartType::Message(message) => message.raw_message.len(),
+            PartType::Message(message) => message.raw_message().len(),
             PartType::Multipart(_) => 0,
         }
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -129,7 +129,12 @@ R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
         )
     );
 
-    let nested_message = message.attachment(0).unwrap().message().unwrap();
+    let nested_part = message.attachment(0).unwrap();
+    assert_eq!(nested_part.len(), 723);
+    assert_eq!(nested_part.body.len(), 723);
+    assert_eq!(nested_part.contents().len(), 723);
+
+    let nested_message = nested_part.message().unwrap();
 
     assert_eq!(
         nested_message.subject().unwrap(),


### PR DESCRIPTION
Related issue: #38

The methods in `PartType` and `MessagePart` should utilize `raw_message()` instead of the field element to avoid returning incorrect values for nested messages.