### PR TITLE
Update lib.rs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,7 +504,7 @@ pub struct ContentType<'x> {
 }
 
 /// An RFC5322 datetime.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde_support", derive(Serialize, Deserialize))]
 pub struct DateTime {
     pub year: u16,


### PR DESCRIPTION
provide default for `DateTime`

For ergonomic reasons an implementation of `Default` for `DateTime` is useful. All zero's and false values are fine, though some specific other value may be more suitable.