### PR TITLE
Draft: Overly restricted/constrained lifetimes

### DIFF
--- a/src/core/header.rs
+++ b/src/core/header.rs
@@ -587,7 +587,7 @@ impl<'x> MimeHeaders<'x> for Message<'x> {
 
 impl<'x> MessagePart<'x> {
     /// Returns the body part's contents as a `u8` slice
-    pub fn contents(&'x self) -> &'x [u8] {
+    pub fn contents(&self) -> &[u8] {
         match &self.body {
             PartType::Text(text) | PartType::Html(text) => text.as_bytes(),
             PartType::Binary(bin) | PartType::InlineBinary(bin) => bin.as_ref(),
@@ -597,7 +597,7 @@ impl<'x> MessagePart<'x> {
     }
 
     /// Returns the body part's contents as a `str`
-    pub fn text_contents(&'x self) -> Option<&'x str> {
+    pub fn text_contents(&self) -> Option<&str> {
         match &self.body {
             PartType::Text(text) | PartType::Html(text) => text.as_ref().into(),
             PartType::Binary(bin) | PartType::InlineBinary(bin) => {
@@ -609,7 +609,7 @@ impl<'x> MessagePart<'x> {
     }
 
     /// Returns the nested message
-    pub fn message(&'x self) -> Option<&Message<'x>> {
+    pub fn message(&self) -> Option<&Message<'x>> {
         if let PartType::Message(message) = &self.body {
             Some(message)
         } else {
@@ -618,7 +618,7 @@ impl<'x> MessagePart<'x> {
     }
 
     /// Returns the sub parts ids of a MIME part
-    pub fn sub_parts(&'x self) -> Option<&[MessagePartId]> {
+    pub fn sub_parts(&self) -> Option<&[MessagePartId]> {
         if let PartType::Multipart(parts) = &self.body {
             Some(parts.as_ref())
         } else {


### PR DESCRIPTION
Some places take in `&'x self` when they shouldn't.

The functions returning iterators, probably need two lifetimes, so that they don't bind the lifetime associated with the input buffer, to self.

But I need a bit more time to play with the code.

Discussion in the discord forums is telling me that some functions, like this one:
```rs
body_html(&'x self, pos: usize) -> Option<Cow<'x, str>> 
```

Could maybe return an `Option<Cow<'_, Cow<'x, str>>>` Which looks a little crazy to me tbh, but i'm told:
> It prevents the need to clone the String if it's not needed