### PR TITLE
Update multi_byte.rs

### DIFF
--- a/src/decoders/charsets/multi_byte.rs
+++ b/src/decoders/charsets/multi_byte.rs
@@ -14,7 +14,7 @@ use encoding_rs::*;
 
 #[cfg(feature = "full_encoding")]
 fn multi_byte_decoder(mut decoder: Decoder, bytes: &[u8]) -> String {
-    let mut result = String::with_capacity(bytes.len() * 3);
+    let mut result = String::with_capacity(bytes.len() * 4);
 
     if let (CoderResult::OutputFull, _, _) = decoder.decode_to_string(bytes, &mut result, true) {
         debug_assert!(false, "String full while decoding.")


### PR DESCRIPTION
Under some extreme circumstances, the pre-allocated length might not be sufficient.

```
#[test]
    fn test2() {
        let input = "?gb2312?B?oQ==?=";
        match MessageStream::new(input.as_bytes()).decode_rfc2047() {
            Some(result) => {
                println!("Decoded '{}'", result);
                //assert_eq!(result, expected_result);
            }
            _ => panic!("Failed to decode '{}'", input),
        
        }
    }
```