### PR TITLE
Add .eml example with odd behavior

### DIFF
--- a/resources/eml/malformed/012.crlf.json
+++ b/resources/eml/malformed/012.crlf.json
@@ -146,11 +146,13 @@
       "is_encoding_problem": false,
       "body": {
         "Message": {
-          "html_body": [],
-          "text_body": [],
-          "attachments": [
+          "html_body": [
             0
           ],
+          "text_body": [
+            0
+          ],
+          "attachments": [],
           "parts": [
             {
               "headers": [

--- a/resources/eml/malformed/012.json
+++ b/resources/eml/malformed/012.json
@@ -146,11 +146,13 @@
       "is_encoding_problem": false,
       "body": {
         "Message": {
-          "html_body": [],
-          "text_body": [],
-          "attachments": [
+          "html_body": [
             0
           ],
+          "text_body": [
+            0
+          ],
+          "attachments": [],
           "parts": [
             {
               "headers": [

--- a/resources/eml/malformed/018.crlf.json
+++ b/resources/eml/malformed/018.crlf.json
@@ -1,0 +1,58 @@
+{
+  "html_body": [
+    0
+  ],
+  "text_body": [
+    0
+  ],
+  "attachments": [],
+  "parts": [
+    {
+      "headers": [
+        {
+          "name": "content_type",
+          "value": {
+            "ContentType": {
+              "c_type": "text",
+              "c_subtype": "plain",
+              "attributes": [
+                [
+                  "charset",
+                  "Windows-1252"
+                ]
+              ]
+            }
+          },
+          "offset_field": 0,
+          "offset_start": 13,
+          "offset_end": 52
+        },
+        {
+          "name": "content_transfer_encoding",
+          "value": {
+            "Text": "quoted-printable"
+          },
+          "offset_field": 52,
+          "offset_start": 78,
+          "offset_end": 97
+        },
+        {
+          "name": "mime_version",
+          "value": {
+            "Text": "1.0"
+          },
+          "offset_field": 97,
+          "offset_start": 110,
+          "offset_end": 116
+        }
+      ],
+      "is_encoding_problem": true,
+      "body": {
+        "Text": "Best\r\nEnviado desde mi BlackBerry=AE de Vodafone=\r\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\r\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\r\n<plist version=\"1.0\">\r\n<dict>\r\n</dict>\r\n</plist>"
+      },
+      "offset_header": 0,
+      "offset_body": 118,
+      "offset_end": 361
+    }
+  ]
+}

--- a/resources/eml/malformed/018.eml
+++ b/resources/eml/malformed/018.eml
@@ -1,0 +1,13 @@
+Content-Type: text/plain;
+	charset="Windows-1252"
+Content-Transfer-Encoding: quoted-printable
+MIME-Version: 1.0
+
+Best
+Enviado desde mi BlackBerry=AE de Vodafone=
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>

--- a/resources/eml/malformed/018.json
+++ b/resources/eml/malformed/018.json
@@ -1,0 +1,58 @@
+{
+  "html_body": [
+    0
+  ],
+  "text_body": [
+    0
+  ],
+  "attachments": [],
+  "parts": [
+    {
+      "headers": [
+        {
+          "name": "content_type",
+          "value": {
+            "ContentType": {
+              "c_type": "text",
+              "c_subtype": "plain",
+              "attributes": [
+                [
+                  "charset",
+                  "Windows-1252"
+                ]
+              ]
+            }
+          },
+          "offset_field": 0,
+          "offset_start": 13,
+          "offset_end": 52
+        },
+        {
+          "name": "content_transfer_encoding",
+          "value": {
+            "Text": "quoted-printable"
+          },
+          "offset_field": 52,
+          "offset_start": 78,
+          "offset_end": 97
+        },
+        {
+          "name": "mime_version",
+          "value": {
+            "Text": "1.0"
+          },
+          "offset_field": 97,
+          "offset_start": 110,
+          "offset_end": 116
+        }
+      ],
+      "is_encoding_problem": true,
+      "body": {
+        "Text": "Best\nEnviado desde mi BlackBerry=AE de Vodafone=\n<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">\n<plist version=\"1.0\">\n<dict>\n</dict>\n</plist>"
+      },
+      "offset_header": 0,
+      "offset_body": 118,
+      "offset_end": 354
+    }
+  ]
+}


### PR DESCRIPTION
This example exhibits strange behavior: `mail-parser` thinks it has a single attachment, although the only part of the email is `plain/text` and there is no multipart boundary. Thunderbird does a best-effort attempt at displaying the part as if it were text.