### PR TITLE
Retain mbox IO errors

### DIFF
--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -76,14 +76,15 @@ where
             if let Some(message) = &mut self.message {
                 if message_line[0] != b'>' {
                     message.contents.extend_from_slice(&message_line);
-                } else if message_line
+                    message_line.clear();
+                    continue;
+                }
+                // can become split_once once slice_split_once becomes stable
+                let i = message_line
                     .iter()
-                    .skip_while(|&&ch| ch == b'>')
-                    .take(5)
-                    .copied()
-                    .collect::<Vec<u8>>()
-                    == b"From "
-                {
+                    .position(|&ch| ch != b'>')
+                    .unwrap_or(message_line.len());
+                if message_line[i..].starts_with(b"From ") {
                     message.contents.extend_from_slice(&message_line[1..]);
                 } else {
                     message.contents.extend_from_slice(&message_line);

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -54,20 +54,12 @@ where
 
         loop {
             match self.reader.read_until(b'\n', &mut message_line) {
-                Ok(bytes_read) => {
-                    if bytes_read == 0 {
-                        break;
-                    }
-                }
-                Err(_) => {
-                    return Some(Err(ParseError {}));
-                }
+                Ok(0) => break,
+                Ok(_) => {}
+                Err(_) => return Some(Err(ParseError {})),
             }
 
-            let is_from = message_line
-                .get(..5)
-                .map(|line| line == b"From ")
-                .unwrap_or(false);
+            let is_from = message_line.starts_with(b"From ");
 
             if let Some(message) = &mut self.message {
                 if !is_from {

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -29,9 +29,6 @@ pub struct Message {
     contents: Vec<u8>,
 }
 
-#[derive(Debug)]
-pub struct ParseError {}
-
 impl<T> MessageIterator<T>
 where
     T: Read,
@@ -48,7 +45,7 @@ impl<T> Iterator for MessageIterator<T>
 where
     T: Read,
 {
-    type Item = Result<Message, ParseError>;
+    type Item = std::io::Result<Message>;
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut message_line = Vec::with_capacity(80);
@@ -57,7 +54,7 @@ where
             match self.reader.read_until(b'\n', &mut message_line) {
                 Ok(0) => return self.message.take().map(Ok),
                 Ok(_) => {}
-                Err(_) => return Some(Err(ParseError {})),
+                Err(e) => return Some(Err(e)),
             }
 
             let is_from = message_line.starts_with(b"From ");

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -73,9 +73,9 @@ where
             }
 
             if let Some(message) = &mut self.message {
-                if message_line[0] != b'>' {
+                if !is_from && message_line[0] != b'>' {
                     message.contents.extend_from_slice(&message_line);
-                } else if message_line
+                } else if !is_from && message_line
                     .iter()
                     .skip_while(|&&ch| ch == b'>')
                     .take(5)
@@ -84,7 +84,7 @@ where
                     == b"From "
                 {
                     message.contents.extend_from_slice(&message_line[1..]);
-                } else {
+                } else if !is_from {
                     message.contents.extend_from_slice(&message_line);
                 }
             }

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -54,7 +54,7 @@ where
 
         loop {
             match self.reader.read_until(b'\n', &mut message_line) {
-                Ok(0) => break,
+                Ok(0) => return self.message.take().map(Ok),
                 Ok(_) => {}
                 Err(_) => return Some(Err(ParseError {})),
             }
@@ -90,8 +90,6 @@ where
             }
             message_line.clear();
         }
-
-        self.message.take().map(Ok)
     }
 }
 

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -61,18 +61,18 @@ where
 
             let is_from = message_line.starts_with(b"From ");
 
-            if let Some(message) = &mut self.message {
-                if is_from && self.message.is_some() {
-                    // self.message is Some here, so message is Some
-                    let message = self.message.take().map(Ok);
-                    self.message =
-                        Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
-                    // branch is always executed due to comment above
-                    // but will not compile because borrow checker doesnt know this
-                    // if message.is_some() {
-                        return message;
-                    // }
+            if is_from && self.message.is_some() {
+                // self.message is Some here, so message is Some
+                let message = self.message.take().map(Ok);
+                self.message =
+                    Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
+                // branch is always executed due to comment above
+                if message.is_some() {
+                    return message;
                 }
+            }
+
+            if let Some(message) = &mut self.message {
                 if message_line[0] != b'>' {
                     message.contents.extend_from_slice(&message_line);
                 } else if message_line

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -14,7 +14,8 @@ use std::io::{BufRead, BufReader, Read};
 
 /// Parses an Mbox mailbox from a `Read` stream, returning each message as a
 /// `Vec<u8>`.
-/// supports >From  quoting as defined in the [QMail mbox specification](http://qmail.org/qmail-manual-html/man5/mbox.html).
+///
+/// Supports >From  quoting as defined in the [QMail mbox specification](http://qmail.org/qmail-manual-html/man5/mbox.html).
 pub struct MessageIterator<T: Read> {
     reader: BufReader<T>,
     message: Option<Message>,

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -87,16 +87,15 @@ where
                 } else {
                     message.contents.extend_from_slice(&message_line);
                 }
-            } else {
-                if is_from && self.message.is_none() {
-                    // self.message is None here, so message is None
-                    let message = self.message.take().map(Ok);
-                    self.message =
-                        Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
-                    // branch doesnt do anything due to comment above
-                    if message.is_some() {
-                        return message;
-                    }
+            }
+            if is_from && self.message.is_none() {
+                // self.message is None here, so message is None
+                let message = self.message.take().map(Ok);
+                self.message =
+                    Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
+                // branch doesnt do anything due to comment above
+                if message.is_some() {
+                    return message;
                 }
             }
             message_line.clear();

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -83,9 +83,15 @@ where
                     message.contents.extend_from_slice(&message_line);
                 }
             } else {
-                if is_from {
+                if is_from && self.message.is_none() {
+                    // self.message is None here, so message is None
+                    let message = self.message.take().map(Ok);
                     self.message =
                         Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
+                    // branch doesnt do anything due to comment above
+                    if message.is_some() {
+                        return message;
+                    }
                 }
             }
             message_line.clear();

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -68,12 +68,14 @@ where
                 if message.is_some() {
                     return message;
                 }
+                message_line.clear();
+                continue;
             }
 
             if let Some(message) = &mut self.message {
-                if !is_from && message_line[0] != b'>' {
+                if message_line[0] != b'>' {
                     message.contents.extend_from_slice(&message_line);
-                } else if !is_from && message_line
+                } else if message_line
                     .iter()
                     .skip_while(|&&ch| ch == b'>')
                     .take(5)
@@ -82,7 +84,7 @@ where
                     == b"From "
                 {
                     message.contents.extend_from_slice(&message_line[1..]);
-                } else if !is_from {
+                } else {
                     message.contents.extend_from_slice(&message_line);
                 }
             }

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -64,7 +64,8 @@ where
             if let Some(message) = &mut self.message {
                 if !is_from {
                     if message_line[0] != b'>' {
-                        message.contents.append(&mut message_line);
+                        message.contents.extend_from_slice(&message_line);
+                        message_line.clear();
                     } else if message_line
                         .iter()
                         .skip_while(|&&ch| ch == b'>')
@@ -76,7 +77,8 @@ where
                         message.contents.extend_from_slice(&message_line[1..]);
                         message_line.clear();
                     } else {
-                        message.contents.append(&mut message_line);
+                        message.contents.extend_from_slice(&message_line);
+                        message_line.clear();
                     }
                 } else {
                     let message = self.message.take().map(Ok);

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -72,6 +72,17 @@ where
                 }
             }
 
+            if is_from && self.message.is_none() {
+                // self.message is None here, so message is None
+                let message = self.message.take().map(Ok);
+                self.message =
+                    Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
+                // branch doesnt do anything due to comment above
+                if message.is_some() {
+                    return message;
+                }
+            }
+
             if let Some(message) = &mut self.message {
                 if !is_from && message_line[0] != b'>' {
                     message.contents.extend_from_slice(&message_line);
@@ -86,16 +97,6 @@ where
                     message.contents.extend_from_slice(&message_line[1..]);
                 } else if !is_from {
                     message.contents.extend_from_slice(&message_line);
-                }
-            }
-            if is_from && self.message.is_none() {
-                // self.message is None here, so message is None
-                let message = self.message.take().map(Ok);
-                self.message =
-                    Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
-                // branch doesnt do anything due to comment above
-                if message.is_some() {
-                    return message;
                 }
             }
             message_line.clear();

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -62,11 +62,16 @@ where
             let is_from = message_line.starts_with(b"From ");
 
             if let Some(message) = &mut self.message {
-                if is_from {
+                if is_from && self.message.is_some() {
+                    // self.message is Some here, so message is Some
                     let message = self.message.take().map(Ok);
                     self.message =
                         Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
-                    return message;
+                    // branch is always executed due to comment above
+                    // but will not compile because borrow checker doesnt know this
+                    // if message.is_some() {
+                        return message;
+                    // }
                 }
                 if message_line[0] != b'>' {
                     message.contents.extend_from_slice(&message_line);

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -62,27 +62,12 @@ where
             let is_from = message_line.starts_with(b"From ");
 
             if is_from {
-            if self.message.is_some() {
-                // self.message is Some here, so message is Some
                 let message = self.message.take().map(Ok);
                 self.message =
                     Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
-                // branch is always executed due to comment above
                 if message.is_some() {
                     return message;
                 }
-            }
-
-            if self.message.is_none() {
-                // self.message is None here, so message is None
-                let message = self.message.take().map(Ok);
-                self.message =
-                    Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
-                // branch doesnt do anything due to comment above
-                if message.is_some() {
-                    return message;
-                }
-            }
             }
 
             if let Some(message) = &mut self.message {

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -65,7 +65,6 @@ where
                 if !is_from {
                     if message_line[0] != b'>' {
                         message.contents.extend_from_slice(&message_line);
-                        message_line.clear();
                     } else if message_line
                         .iter()
                         .skip_while(|&&ch| ch == b'>')
@@ -75,10 +74,8 @@ where
                         == b"From "
                     {
                         message.contents.extend_from_slice(&message_line[1..]);
-                        message_line.clear();
                     } else {
                         message.contents.extend_from_slice(&message_line);
-                        message_line.clear();
                     }
                 } else {
                     let message = self.message.take().map(Ok);
@@ -91,8 +88,8 @@ where
                     self.message =
                         Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
                 }
-                message_line.clear();
             }
+            message_line.clear();
         }
 
         self.message.take().map(Ok)

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -62,7 +62,12 @@ where
             let is_from = message_line.starts_with(b"From ");
 
             if let Some(message) = &mut self.message {
-                if !is_from {
+                if is_from {
+                    let message = self.message.take().map(Ok);
+                    self.message =
+                        Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
+                    return message;
+                } else {
                     if message_line[0] != b'>' {
                         message.contents.extend_from_slice(&message_line);
                     } else if message_line
@@ -77,11 +82,6 @@ where
                     } else {
                         message.contents.extend_from_slice(&message_line);
                     }
-                } else {
-                    let message = self.message.take().map(Ok);
-                    self.message =
-                        Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
-                    return message;
                 }
             } else {
                 if is_from {

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -67,7 +67,7 @@ where
                     self.message =
                         Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
                     return message;
-                } else {
+                }
                     if message_line[0] != b'>' {
                         message.contents.extend_from_slice(&message_line);
                     } else if message_line
@@ -82,7 +82,6 @@ where
                     } else {
                         message.contents.extend_from_slice(&message_line);
                     }
-                }
             } else {
                 if is_from {
                     self.message =

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -68,20 +68,20 @@ where
                         Message::new(std::str::from_utf8(&message_line).unwrap_or("")).into();
                     return message;
                 }
-                    if message_line[0] != b'>' {
-                        message.contents.extend_from_slice(&message_line);
-                    } else if message_line
-                        .iter()
-                        .skip_while(|&&ch| ch == b'>')
-                        .take(5)
-                        .copied()
-                        .collect::<Vec<u8>>()
-                        == b"From "
-                    {
-                        message.contents.extend_from_slice(&message_line[1..]);
-                    } else {
-                        message.contents.extend_from_slice(&message_line);
-                    }
+                if message_line[0] != b'>' {
+                    message.contents.extend_from_slice(&message_line);
+                } else if message_line
+                    .iter()
+                    .skip_while(|&&ch| ch == b'>')
+                    .take(5)
+                    .copied()
+                    .collect::<Vec<u8>>()
+                    == b"From "
+                {
+                    message.contents.extend_from_slice(&message_line[1..]);
+                } else {
+                    message.contents.extend_from_slice(&message_line);
+                }
             } else {
                 if is_from {
                     self.message =

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -61,7 +61,8 @@ where
 
             let is_from = message_line.starts_with(b"From ");
 
-            if is_from && self.message.is_some() {
+            if is_from {
+            if self.message.is_some() {
                 // self.message is Some here, so message is Some
                 let message = self.message.take().map(Ok);
                 self.message =
@@ -72,7 +73,7 @@ where
                 }
             }
 
-            if is_from && self.message.is_none() {
+            if self.message.is_none() {
                 // self.message is None here, so message is None
                 let message = self.message.take().map(Ok);
                 self.message =
@@ -81,6 +82,7 @@ where
                 if message.is_some() {
                     return message;
                 }
+            }
             }
 
             if let Some(message) = &mut self.message {


### PR DESCRIPTION
I've made again an effort to keep every commit diff as small as possible. They should not affect observable behavior and all tests pass on every commit.