### PR TITLE
Hide concrete type behind impl trait

### DIFF
--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -449,17 +449,17 @@ impl<'x> Message<'x> {
     }
 
     /// Returns an Interator over the text body parts
-    pub fn text_bodies(&'x self) -> BodyPartIterator<'x> {
+    pub fn text_bodies(&self) -> impl Iterator<Item = &'_ MessagePart<'_>> {
         BodyPartIterator::new(self, &self.text_body)
     }
 
     /// Returns an Interator over the HTML body parts
-    pub fn html_bodies(&'x self) -> BodyPartIterator<'x> {
+    pub fn html_bodies(&self) -> impl Iterator<Item = &'_ MessagePart<'_>> {
         BodyPartIterator::new(self, &self.html_body)
     }
 
     /// Returns an Interator over the attachments
-    pub fn attachments(&'x self) -> AttachmentIterator<'x> {
+    pub fn attachments(&self) -> impl Iterator<Item = &'_ MessagePart<'_>> {
         AttachmentIterator::new(self)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -654,15 +654,13 @@ pub trait GetHeader<'x> {
     fn header(&self, name: impl Into<HeaderName<'x>>) -> Option<&Header<'x>>;
 }
 
-#[doc(hidden)]
-pub struct BodyPartIterator<'x> {
+struct BodyPartIterator<'x> {
     message: &'x Message<'x>,
     list: &'x [MessagePartId],
     pos: isize,
 }
 
-#[doc(hidden)]
-pub struct AttachmentIterator<'x> {
+struct AttachmentIterator<'x> {
     message: &'x Message<'x>,
     pos: isize,
 }


### PR DESCRIPTION
Without this, the doc(hidden) interacts poorly with the fact that both `BodyPartIterator` and `AttachmentIterator` can be found in the public api of other functions. The types still show up, but there's no simple way to know they implement Iterator or what the Item they return is.

Alternatively, remove doc(hidden) instead of hiding type behind impl trait.