### PR TITLE
Prevent double buffering by exposing the `BufRead` bound

### DIFF
--- a/examples/mailbox_parse_mbox.rs
+++ b/examples/mailbox_parse_mbox.rs
@@ -8,7 +8,7 @@ use mail_parser::{mailbox::mbox::MessageIterator, MessageParser};
 
 fn main() {
     // Reads an MBox mailbox from stdin and prints each message as JSON.
-    for raw_message in MessageIterator::new(std::io::stdin()) {
+    for raw_message in MessageIterator::new(std::io::stdin().lock()) {
         let raw_message = raw_message.unwrap();
         let message = MessageParser::default()
             .parse(raw_message.contents())

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -5,14 +5,14 @@
  */
 
 use crate::DateTime;
-use std::io::{BufRead, BufReader, Read};
+use std::io::BufRead;
 
 /// Parses an Mbox mailbox from a `Read` stream, returning each message as a
 /// `Vec<u8>`.
 ///
 /// Supports >From  quoting as defined in the [QMail mbox specification](http://qmail.org/qmail-manual-html/man5/mbox.html).
-pub struct MessageIterator<T: Read> {
-    reader: BufReader<T>,
+pub struct MessageIterator<T> {
+    reader: T,
     message: Option<Message>,
 }
 
@@ -26,11 +26,11 @@ pub struct Message {
 
 impl<T> MessageIterator<T>
 where
-    T: Read,
+    T: BufRead,
 {
     pub fn new(reader: T) -> MessageIterator<T> {
         MessageIterator {
-            reader: BufReader::new(reader),
+            reader,
             message: None,
         }
     }
@@ -38,7 +38,7 @@ where
 
 impl<T> Iterator for MessageIterator<T>
 where
-    T: Read,
+    T: BufRead,
 {
     type Item = std::io::Result<Message>;
 


### PR DESCRIPTION
This is a bit of a nit, but interfaces that expose `Read` bounds should not do internal buffering, as this risks the caller accidentally passing a type that is already buffered, resulting in double buffering. Instead, by exposing the `BufRead` bound the caller is forced to buffer if he tries passing a type that only implements `Read`. Since the caller has better awareness of the code he is writing, he is much less likely to accidentally buffer a reader twice.