### PR TITLE
fix-no-newline-parse

### DIFF
--- a/src/parsers/fields/raw.rs
+++ b/src/parsers/fields/raw.rs
@@ -37,7 +37,13 @@ impl<'x> MessageStream<'x> {
             token_end = self.offset();
         }
 
-        HeaderValue::Empty
+        if token_start > 0 {
+            HeaderValue::Text(String::from_utf8_lossy(
+                self.bytes(token_start - 1..token_end),
+            ))
+        } else {
+            HeaderValue::Empty
+        }
     }
 
     pub fn parse_and_ignore(&mut self) {
@@ -70,6 +76,7 @@ mod tests {
                     "for <mary@example.net>;  21 Nov 1997 10:05:43 -0600"
                 ),
             ),
+            ("Re: Saying Hello", "Re: Saying Hello"), // No newline test
         ];
 
         for (input, expected) in inputs {

--- a/src/parsers/fields/raw.rs
+++ b/src/parsers/fields/raw.rs
@@ -15,13 +15,7 @@ impl<'x> MessageStream<'x> {
             match ch {
                 b'\n' => {
                     if !self.try_next_is_space() {
-                        return if token_start > 0 {
-                            HeaderValue::Text(String::from_utf8_lossy(
-                                self.bytes(token_start - 1..token_end),
-                            ))
-                        } else {
-                            HeaderValue::Empty
-                        };
+                        break;
                     } else {
                         continue;
                     }


### PR DESCRIPTION
Dearest Reviewer,

Issue #90 brought up an issue that if there was no newline it would fail. the user provided an easy reproduction case. I was able to track it down to the parse raw function.

The issue is that the loop hits the end of the string and returns Empty. However, if there is a start offset then some characters were found. This code just checks the offset after the loop.

If this is not the correct behavior please close.

Thanks for your time
Becker