### PR TITLE
receive header folding

### DIFF
--- a/resources/received.json
+++ b/resources/received.json
@@ -4200,5 +4200,31 @@
         "tz_minute": 0
       }
     }
+  },
+  {
+    "header": " from [127.0.0.1] (host.example.com [35.173.1.1])\r\n by bf7aa1d4e8a6 with SMTP id 660a079b99f27ed5a03038a8; Mon, 01 Apr 2024\r\n 01:02:19 GMT\r\n",
+    "expected": {
+      "from": {
+        "IpAddr": "127.0.0.1"
+      },
+      "from_ip": "35.173.1.1",
+      "from_iprev": "host.example.com",
+      "by": {
+        "Name": "bf7aa1d4e8a6"
+      },
+      "with": "SMTP",
+      "id": "660a079b99f27ed5a03038a8",
+      "date": {
+        "year": 2024,
+        "month": 4,
+        "day": 1,
+        "hour": 1,
+        "minute": 2,
+        "second": 19,
+        "tz_before_gmt": true,
+        "tz_hour": 0,
+        "tz_minute": 0
+      }
+    }
   }
 ]

--- a/src/parsers/fields/received.rs
+++ b/src/parsers/fields/received.rs
@@ -582,9 +582,12 @@ impl<'x> Iterator for Tokenizer<'x, '_> {
             | (0, 1.., 0, 0, 0, 0, 0, 0, 1, 0, _)
             | (0, 1.., 0, 0, 0, 0, 0, 1, 0, 0, _) => {
                 // Integer
-                text.parse::<i64>()
-                    .map(Token::Integer)
-                    .unwrap_or(Token::Text)
+                text.parse::<i64>().map(Token::Integer).unwrap_or_else(|_| {
+                    text.trim()
+                        .parse::<i64>()
+                        .map(Token::Integer)
+                        .unwrap_or(Token::Text)
+                })
             }
             (1.., _, _, _, 1, _, _, _, _, _, _) | (_, _, 1.., _, 1, _, _, _, _, _, _) => {
                 // E-mail address


### PR DESCRIPTION
Dearest Reviewer,

I looked at issue #81 and found that the CRLF was adding whitespace to the text during the integer parsing. I added a trim call to the error flow and try parsing again. I did this because it appears to be the exceptional case and normal flows will not take the cost of trim with every process. I can move the trim back out.

I used the failing test that was provided.

Thanks for your time
Becker