### PR TITLE
Fixed typo in header.rs

### DIFF
--- a/src/core/header.rs
+++ b/src/core/header.rs
@@ -656,7 +656,7 @@ impl<'x> MessagePart<'x> {
         matches!(self.body, PartType::Text(_) | PartType::Html(_))
     }
 
-    /// Returns `true` when the body part MIME type is text/tml
+    /// Returns `true` when the body part MIME type is text/html
     pub fn is_text_html(&self) -> bool {
         matches!(self.body, PartType::Html(_))
     }


### PR DESCRIPTION
Just a very very small fix for a typo that I noticed while reading the docs.
Thanks for the great plugin, it really helped me in a personal project I've been working on!

Have a nice day