### PR TITLE
Break line when encountering ``<div>`` tag

### DIFF
--- a/src/decoders/html.rs
+++ b/src/decoders/html.rs
@@ -78,7 +78,8 @@ pub fn html_to_text(input: &str) -> String {
                         match input.get(token_start..token_end + 1) {
                             Some(tag)
                                 if tag.eq_ignore_ascii_case(b"br")
-                                    || (tag.eq_ignore_ascii_case(b"p") && is_tag_close) =>
+                                    || (tag.eq_ignore_ascii_case(b"p") && is_tag_close)
+                                    || (tag.eq_ignore_ascii_case(b"div") && is_tag_close) =>
                             {
                                 result.push('\n');
                                 is_after_space = false;
@@ -2389,6 +2390,13 @@ mod tests {
             (
                 " <p>please unsubscribe <a href=#>here</a>.</p> ",
                 "please unsubscribe here.\n",
+            ),
+            (
+                concat!(
+                    "<div>what is the</div>weather <div>",
+                    "today</div>"
+                ),
+                "what is the\nweather today\n",
             ),
         ];
 


### PR DESCRIPTION
``<div>`` is block-level element by default, let it behaves like a `<p>` element.

---

BTW, A block-level element always starts on a new line and ends on a new line, so the condition would be better to change from:

```rust
tag.eq_ignore_ascii_case(b"p") && is_tag_close
```

to:

```rust
tag.eq_ignore_ascii_case(b"p")
```

![图片](https://github.com/user-attachments/assets/ce21eade-4d53-47a7-b821-28260e7f6f5b)

I’m not sure if there was any special consideration for doing this before, so I kept the condition unchanged in this PR.
