### PR TITLE
Property based testing of folding whitespace

### DIFF
--- a/src/decoders/encoded_word.rs
+++ b/src/decoders/encoded_word.rs
@@ -164,10 +164,9 @@ mod tests {
         ] {
             match MessageStream::new(input.as_bytes()).decode_rfc2047() {
                 Some(result) => {
-                    //println!("Decoded '{}'", string);
                     assert_eq!(result, expected_result);
                 }
-                _ => panic!("Failed to decode '{}'", input),
+                _ => panic!("Failed to decode '{input}'"),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use parsers::MessageStream;
 use std::{borrow::Cow, collections::HashMap, hash::Hash, net::IpAddr};
 
 /// RFC5322/RFC822 message parser.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, Clone)]
 pub struct MessageParser {
     pub(crate) header_map: HashMap<HeaderName<'static>, HdrParseFnc>,
     pub(crate) def_hdr_parse_fnc: HdrParseFnc,

--- a/src/parsers/fields/date.rs
+++ b/src/parsers/fields/date.rs
@@ -493,6 +493,17 @@ mod tests {
             let datetime = MessageStream::new(test.header.as_bytes())
                 .parse_date()
                 .into_datetime();
+
+            if let Some(datetime) = &datetime {
+                if datetime.is_valid() {
+                    let folding_ws = datetime.to_rfc822().replace(" ", " \t\r\n\t  ");
+                    let dt = MessageStream::new(folding_ws.as_bytes())
+                        .parse_date()
+                        .into_datetime();
+                    assert_eq!(Some(datetime), dt.as_ref(), "{}", &test.header);
+                }
+            }
+
             assert_eq!(datetime, test.expected, "failed for {:?}", test.header);
 
             match datetime {

--- a/src/parsers/fields/raw.rs
+++ b/src/parsers/fields/raw.rs
@@ -79,8 +79,7 @@ mod tests {
                     .parse_raw()
                     .unwrap_text(),
                 expected,
-                "Failed for '{:?}'",
-                input
+                "Failed for '{input:?}'",
             );
         }
     }


### PR DESCRIPTION
There have previously been some bugs with handling folding whitespace. This seems like a good target for a property-based test.

This PR introduces a small property-based test for dates that ensures the date parser treats folding whitespace correctly.