### PR TITLE
Delay creation of HeaderValues

### DIFF
--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -17,7 +17,7 @@ impl MessageParser {
     pub fn new() -> Self {
         Self {
             header_map: Default::default(),
-            def_hdr_parse_fnc: |s| s.parse_raw(),
+            def_hdr_parse_fnc: |s| s.parse_raw().into(),
         }
     }
 
@@ -122,19 +122,21 @@ impl MessageParser {
     /// Parse a header as text decoding RFC 2047 encoded words.
     pub fn header_text(mut self, header: impl Into<HeaderName<'static>>) -> Self {
         self.header_map
-            .insert(header.into(), |s| s.parse_unstructured());
+            .insert(header.into(), |s| s.parse_unstructured().into());
         self
     }
 
     /// Parse a header as a RFC 5322 date.
     pub fn header_date(mut self, header: impl Into<HeaderName<'static>>) -> Self {
-        self.header_map.insert(header.into(), |s| s.parse_date());
+        self.header_map
+            .insert(header.into(), |s| s.parse_date().into());
         self
     }
 
     /// Parse a header as an address.
     pub fn header_address(mut self, header: impl Into<HeaderName<'static>>) -> Self {
-        self.header_map.insert(header.into(), |s| s.parse_address());
+        self.header_map
+            .insert(header.into(), |s| s.parse_address().into());
         self
     }
 
@@ -147,7 +149,7 @@ impl MessageParser {
     /// Parse a header as a MIME `Content-Type` or `Content-Disposition` type.
     pub fn header_content_type(mut self, header: impl Into<HeaderName<'static>>) -> Self {
         self.header_map
-            .insert(header.into(), |s| s.parse_content_type());
+            .insert(header.into(), |s| s.parse_content_type().into());
         self
     }
 
@@ -161,13 +163,14 @@ impl MessageParser {
     /// Parse a header as a received header.
     pub fn header_received(mut self, header: impl Into<HeaderName<'static>>) -> Self {
         self.header_map
-            .insert(header.into(), |s| s.parse_received());
+            .insert(header.into(), |s| s.parse_received().map(Box::new).into());
         self
     }
 
     /// Parse a header as a raw string, no RFC 2047 decoding is done.
     pub fn header_raw(mut self, header: impl Into<HeaderName<'static>>) -> Self {
-        self.header_map.insert(header.into(), |s| s.parse_raw());
+        self.header_map
+            .insert(header.into(), |s| s.parse_raw().into());
         self
     }
 
@@ -182,13 +185,13 @@ impl MessageParser {
 
     /// Parse all other headers as text decoding RFC 2047 encoded words.
     pub fn default_header_text(mut self) -> Self {
-        self.def_hdr_parse_fnc = |s| s.parse_unstructured();
+        self.def_hdr_parse_fnc = |s| s.parse_unstructured().into();
         self
     }
 
     /// Parse all other headers as raw strings, no RFC 2047 decoding is done.
     pub fn default_header_raw(mut self) -> Self {
-        self.def_hdr_parse_fnc = |s| s.parse_raw();
+        self.def_hdr_parse_fnc = |s| s.parse_raw().into();
         self
     }
 

--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -63,14 +63,18 @@ impl<'x> Message<'x> {
                             HeaderForm::Raw => HeaderValue::Text(
                                 std::str::from_utf8(bytes).unwrap_or_default().trim().into(),
                             ),
-                            HeaderForm::Text => MessageStream::new(bytes).parse_unstructured(),
-                            HeaderForm::Addresses => MessageStream::new(bytes).parse_address(),
+                            HeaderForm::Text => {
+                                MessageStream::new(bytes).parse_unstructured().into()
+                            }
+                            HeaderForm::Addresses => {
+                                MessageStream::new(bytes).parse_address().into()
+                            }
                             HeaderForm::GroupedAddresses => {
-                                MessageStream::new(bytes).parse_address()
+                                MessageStream::new(bytes).parse_address().into()
                             }
                             HeaderForm::MessageIds => MessageStream::new(bytes).parse_id(),
-                            HeaderForm::Date => MessageStream::new(bytes).parse_date(),
-                            HeaderForm::URLs => MessageStream::new(bytes).parse_address(),
+                            HeaderForm::Date => MessageStream::new(bytes).parse_date().into(),
+                            HeaderForm::URLs => MessageStream::new(bytes).parse_address().into(),
                         }),
                 );
             }

--- a/src/decoders/encoded_word.rs
+++ b/src/decoders/encoded_word.rs
@@ -167,7 +167,7 @@ mod tests {
                     //println!("Decoded '{}'", string);
                     assert_eq!(result, expected_result);
                 }
-                _ => panic!("Failed to decode '{}'", input),
+                _ => panic!("Failed to decode '{input}'"),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,50 @@ pub mod decoders;
 pub mod mailbox;
 pub mod parsers;
 
+impl<'x> From<Option<Address<'x>>> for HeaderValue<'x> {
+    fn from(src: Option<Address<'x>>) -> HeaderValue<'x> {
+        match src {
+            Some(x) => HeaderValue::Address(x),
+            None => HeaderValue::Empty,
+        }
+    }
+}
+impl<'x> From<Option<Cow<'x, str>>> for HeaderValue<'x> {
+    fn from(src: Option<Cow<'x, str>>) -> HeaderValue<'x> {
+        match src {
+            Some(x) => HeaderValue::Text(x),
+            None => HeaderValue::Empty,
+        }
+    }
+}
+
+impl<'x> From<Option<DateTime>> for HeaderValue<'x> {
+    fn from(src: Option<DateTime>) -> HeaderValue<'x> {
+        match src {
+            Some(x) => HeaderValue::DateTime(x),
+            None => HeaderValue::Empty,
+        }
+    }
+}
+
+impl<'x> From<Option<ContentType<'x>>> for HeaderValue<'x> {
+    fn from(src: Option<ContentType<'x>>) -> HeaderValue<'x> {
+        match src {
+            Some(x) => HeaderValue::ContentType(x),
+            None => HeaderValue::Empty,
+        }
+    }
+}
+
+impl<'x> From<Option<Box<Received<'x>>>> for HeaderValue<'x> {
+    fn from(src: Option<Box<Received<'x>>>) -> HeaderValue<'x> {
+        match src {
+            Some(x) => HeaderValue::Received(x),
+            None => HeaderValue::Empty,
+        }
+    }
+}
+
 use parsers::MessageStream;
 use std::{borrow::Cow, collections::HashMap, hash::Hash, net::IpAddr};
 

--- a/src/parsers/fields/address.rs
+++ b/src/parsers/fields/address.rs
@@ -6,7 +6,7 @@
 
 use std::borrow::Cow;
 
-use crate::{parsers::MessageStream, Addr, Address, Group, HeaderValue};
+use crate::{parsers::MessageStream, Addr, Address, Group};
 
 #[derive(PartialEq, Clone, Copy, Debug)]
 enum AddressState {
@@ -191,7 +191,7 @@ impl<'x> AddressParser<'x> {
 }
 
 impl<'x> MessageStream<'x> {
-    pub fn parse_address(&mut self) -> HeaderValue<'x> {
+    pub fn parse_address(&mut self) -> Option<Address<'x>> {
         let mut parser = AddressParser {
             token_start: 0,
             token_end: 0,
@@ -354,11 +354,11 @@ impl<'x> MessageStream<'x> {
 
         if parser.group_name.is_some() || !parser.result.is_empty() {
             parser.add_group();
-            HeaderValue::Address(Address::Group(parser.result))
+            Some(Address::Group(parser.result))
         } else if !parser.addresses.is_empty() {
-            HeaderValue::Address(Address::List(parser.addresses))
+            Some(Address::List(parser.addresses))
         } else {
-            HeaderValue::Empty
+            None
         }
     }
 }
@@ -468,7 +468,7 @@ mod tests {
             assert_eq!(
                 MessageStream::new(test.header.as_bytes())
                     .parse_address()
-                    .unwrap_address(),
+                    .unwrap(),
                 test.expected,
                 "failed for {:?}",
                 test.header

--- a/src/parsers/fields/date.rs
+++ b/src/parsers/fields/date.rs
@@ -6,7 +6,7 @@
 
 use std::fmt;
 
-use crate::{parsers::MessageStream, DateTime, HeaderValue};
+use crate::{parsers::MessageStream, DateTime};
 
 pub static DOW: &[&str] = &["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
 pub static MONTH: &[&str] = &[
@@ -16,10 +16,7 @@ pub static MONTH: &[&str] = &[
 impl DateTime {
     /// Parses an RFC822 date
     pub fn parse_rfc822(value: &str) -> Option<Self> {
-        match MessageStream::new(value.as_bytes()).parse_date() {
-            HeaderValue::DateTime(dt) => dt.into(),
-            _ => None,
-        }
+        MessageStream::new(value.as_bytes()).parse_date()
     }
 
     /// Parses an RFC3339 date
@@ -283,7 +280,7 @@ impl fmt::Display for DateTime {
 }
 
 impl<'x> MessageStream<'x> {
-    pub fn parse_date(&mut self) -> HeaderValue<'x> {
+    pub fn parse_date(&mut self) -> Option<DateTime> {
         let mut pos = 0;
         let mut parts = [0u32; 7];
         let mut parts_sizes = [
@@ -413,7 +410,7 @@ impl<'x> MessageStream<'x> {
         }
 
         if pos >= 6 {
-            HeaderValue::DateTime(DateTime {
+            Some(DateTime {
                 year: if (0..=49).contains(&parts[2]) {
                     parts[2] + 2000
                 } else if (50..=99).contains(&parts[2]) {
@@ -435,7 +432,7 @@ impl<'x> MessageStream<'x> {
                 tz_before_gmt: !is_plus,
             })
         } else {
-            HeaderValue::Empty
+            None
         }
     }
     // 4.3 obsolete date and time
@@ -490,9 +487,7 @@ mod tests {
     #[test]
     fn parse_dates() {
         for test in load_tests("date.json") {
-            let datetime = MessageStream::new(test.header.as_bytes())
-                .parse_date()
-                .into_datetime();
+            let datetime = MessageStream::new(test.header.as_bytes()).parse_date();
             assert_eq!(datetime, test.expected, "failed for {:?}", test.header);
 
             match datetime {

--- a/src/parsers/fields/raw.rs
+++ b/src/parsers/fields/raw.rs
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use crate::{parsers::MessageStream, HeaderValue};
+use crate::parsers::MessageStream;
 
 impl<'x> MessageStream<'x> {
-    pub fn parse_raw(&mut self) -> HeaderValue<'x> {
+    pub fn parse_raw(&mut self) -> Option<std::borrow::Cow<'x, str>> {
         let mut token_start: usize = 0;
         let mut token_end: usize = 0;
 
@@ -32,11 +32,11 @@ impl<'x> MessageStream<'x> {
         }
 
         if token_start > 0 {
-            HeaderValue::Text(String::from_utf8_lossy(
+            Some(String::from_utf8_lossy(
                 self.bytes(token_start - 1..token_end),
             ))
         } else {
-            HeaderValue::Empty
+            None
         }
     }
 
@@ -75,9 +75,7 @@ mod tests {
 
         for (input, expected) in inputs {
             assert_eq!(
-                MessageStream::new(input.as_bytes())
-                    .parse_raw()
-                    .unwrap_text(),
+                MessageStream::new(input.as_bytes()).parse_raw().unwrap(),
                 expected,
                 "Failed for '{:?}'",
                 input

--- a/src/parsers/fields/raw.rs
+++ b/src/parsers/fields/raw.rs
@@ -77,8 +77,7 @@ mod tests {
             assert_eq!(
                 MessageStream::new(input.as_bytes()).parse_raw().unwrap(),
                 expected,
-                "Failed for '{:?}'",
-                input
+                "Failed for '{input:?}'"
             );
         }
     }

--- a/src/parsers/fields/received.rs
+++ b/src/parsers/fields/received.rs
@@ -6,9 +6,7 @@
 
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-use crate::{
-    parsers::MessageStream, DateTime, Greeting, HeaderValue, Host, Protocol, Received, TlsVersion,
-};
+use crate::{parsers::MessageStream, DateTime, Greeting, Host, Protocol, Received, TlsVersion};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Token {
@@ -90,7 +88,7 @@ enum State {
 }
 
 impl<'x> MessageStream<'x> {
-    pub fn parse_received(&mut self) -> HeaderValue<'x> {
+    pub fn parse_received(&mut self) -> Option<Received<'x>> {
         //let c = print!("-> {}", std::str::from_utf8(self.data).unwrap());
 
         let mut tokenizer = Tokenizer::new(self).peekable();
@@ -353,9 +351,9 @@ impl<'x> MessageStream<'x> {
             || received.via.is_some()
             || received.date.is_some()
         {
-            HeaderValue::Received(Box::new(received))
+            Some(received)
         } else {
-            HeaderValue::Empty
+            None
         }
     }
 }
@@ -824,7 +822,7 @@ mod tests {
             assert_eq!(
                 MessageStream::new(test.header.as_bytes())
                     .parse_received()
-                    .unwrap_received(),
+                    .unwrap(),
                 test.expected,
                 "failed for {:?}",
                 test.header

--- a/src/parsers/header.rs
+++ b/src/parsers/header.rs
@@ -39,7 +39,7 @@ impl<'x> MessageStream<'x> {
                         | HeaderName::Comments
                         | HeaderName::ContentDescription
                         | HeaderName::ContentLocation
-                        | HeaderName::ContentTransferEncoding => self.parse_unstructured(),
+                        | HeaderName::ContentTransferEncoding => self.parse_unstructured().into(),
                         HeaderName::From
                         | HeaderName::To
                         | HeaderName::Cc
@@ -57,8 +57,8 @@ impl<'x> MessageStream<'x> {
                         | HeaderName::ListOwner
                         | HeaderName::ListPost
                         | HeaderName::ListSubscribe
-                        | HeaderName::ListUnsubscribe => self.parse_address(),
-                        HeaderName::Date | HeaderName::ResentDate => self.parse_date(),
+                        | HeaderName::ListUnsubscribe => self.parse_address().into(),
+                        HeaderName::Date | HeaderName::ResentDate => self.parse_date().into(),
                         HeaderName::MessageId
                         | HeaderName::References
                         | HeaderName::InReplyTo
@@ -68,12 +68,12 @@ impl<'x> MessageStream<'x> {
                         HeaderName::Keywords | HeaderName::ContentLanguage => {
                             self.parse_comma_separared()
                         }
-                        HeaderName::Received => self.parse_received(),
-                        HeaderName::MimeVersion => self.parse_raw(),
+                        HeaderName::Received => self.parse_received().map(Box::new).into(),
+                        HeaderName::MimeVersion => self.parse_raw().into(),
                         HeaderName::ContentType | HeaderName::ContentDisposition => {
-                            self.parse_content_type()
+                            self.parse_content_type().into()
                         }
-                        _ => self.parse_raw(),
+                        _ => self.parse_raw().into(),
                     }
                 } else {
                     (conf


### PR DESCRIPTION
Some of the lower-level apis would benefit from returning the more precise type instead of eagerly wrapping into a `HeaderValue`. This makes the lower-level apis easier to reason about and improves code completion in an IDE. With this change, the `fn unwrap_{received, datetime, text, ...}` are no longer internally used.