### PR TITLE
fix: prevent panic when parts array is empty (backport for v0.9.x)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mail-parser"
 description = "Fast and robust e-mail parsing library for Rust"
-version = "0.9.2"
+version = "0.9.4"
 edition = "2021"
 authors = [ "Stalwart Labs <hello@stalw.art>"]
 license = "Apache-2.0 OR MIT"

--- a/src/parsers/message.rs
+++ b/src/parsers/message.rs
@@ -524,8 +524,8 @@ impl MessageParser {
 
         message.raw_message = raw_message.into();
 
-        if !message.is_empty() {
-            message.parts[0].offset_end = message.raw_message.len();
+        if let Some(part) = message.parts.first_mut() {
+            part.offset_end = message.raw_message.len();
             Some(message)
         } else if !part_headers.is_empty() {
             // Message without a body


### PR DESCRIPTION
## Problem

When parsing some emails, `message.parts` can be empty. The current code directly accesses `parts[0]` without checking, which causes a panic:

```
index out of bounds: the len is 0 but the index is 0
at src/parsers/message.rs:528
```

I found this bug while using [himalaya](https://github.com/pimalaya/himalaya) to send emails. Himalaya uses mail-parser v0.9.4.

## Solution

Change direct array access to safe `first_mut()` method:

```rust
// Before (panic if parts is empty)
message.parts[0].offset_end = message.raw_message.len();

// After (safe)
if let Some(part) = message.parts.first_mut() {
    part.offset_end = message.raw_message.len();
}
```

## Related

This is a backport of the fix from PR #121 to v0.9.x version. PR #121 fixes this for v0.11.x, but himalaya and other projects still use v0.9.x.

## Testing

- Built himalaya with this patch
- The panic is gone
- Errors are now handled properly instead of crashing