### PR TITLE
Treat text/calendar as an inline body part

### DIFF
--- a/src/parsers/message.rs
+++ b/src/parsers/message.rs
@@ -53,6 +53,7 @@ fn mime_type(
             "text" => match content_type.subtype() {
                 Some("plain") => (false, true, true, MimeType::TextPlain),
                 Some("html") => (false, true, true, MimeType::TextHtml),
+                Some("calendar") => (false, true, true, MimeType::TextOther),
                 _ => (false, false, true, MimeType::TextOther),
             },
             "image" | "audio" | "video" => (false, true, false, MimeType::Inline),

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -150,3 +150,38 @@ R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
         "Book about ☕ tables.gif"
     );
 }
+
+#[test]
+fn test_text_calendar_is_treated_as_inline_body() {
+    let input = br#"From: organizer@example.com
+To: attendee@example.com
+Subject: Calendar reply
+MIME-Version: 1.0
+Content-Type: text/calendar; method=REPLY; charset="utf-8"
+Content-Transfer-Encoding: 8bit
+
+BEGIN:VCALENDAR
+VERSION:2.0
+METHOD:REPLY
+BEGIN:VEVENT
+SUMMARY:Accepted: Team Sync
+DTSTART:20260109T025000Z
+DTEND:20260109T041500Z
+END:VEVENT
+END:VCALENDAR
+"#;
+
+    let message = MessageParser::default().parse(input).unwrap();
+
+    assert_eq!(message.text_body_count(), 1);
+    assert_eq!(message.html_body_count(), 1);
+    assert_eq!(message.attachment_count(), 0);
+    assert_eq!(message.parts.len(), 1);
+
+    assert!(message.body_text(0).unwrap().contains("BEGIN:VCALENDAR"));
+    assert!(message
+        .body_text(0)
+        .unwrap()
+        .contains("SUMMARY:Accepted: Team Sync"));
+    assert!(message.body_html(0).unwrap().contains("BEGIN:VCALENDAR"));
+}


### PR DESCRIPTION
## Summary
- classify `text/calendar` as an inline text body part instead of a generic attachment
- preserve existing behavior for other `text/*` subtypes by limiting the change to `calendar`
- add an integration test covering a standalone calendar reply message

## Why
Standalone calendar replies currently parse as:
- `text_body=[]`
- `html_body=[]`
- `attachments=[0]`

That drops the iCalendar payload from the message body APIs even though it is inline textual content.

## Testing
- `cargo test`
