### PR TITLE
feat: add cli

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ resolver = "2"
 hashify = { version = "0.2" }
 encoding_rs = { version = "0.8", optional = true }
 serde = { version = "1.0", features = ["derive"], optional = true }
+serde_json = { version = "1.0", optional = true }
+clap = { version = "4", features = ["derive"], optional = true }
 rkyv = { version = "0.8", optional = true }
 
 [dev-dependencies]
@@ -30,6 +32,7 @@ default = []
 full_encoding = ["encoding_rs"]
 serde = ["dep:serde"]
 rkyv = ["dep:rkyv"]
+cli = ["dep:clap", "dep:serde_json", "full_encoding", "serde"]
 
 [profile.bench]
 debug = true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
 use std::{
     fs,
     io::{stdin, BufRead, IsTerminal},

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,79 @@
+use std::{
+    fs,
+    io::{stdin, BufRead, IsTerminal},
+    path::PathBuf,
+    process::exit,
+};
+
+use clap::Parser;
+use mail_parser::MessageParser;
+
+/// Parse an e-mail and print its JSON structure.
+#[derive(Debug, Parser)]
+#[command(name = env!("CARGO_PKG_NAME"), author, version)]
+pub struct Cli {
+    /// Raw message content or path to a file.
+    ///
+    /// Omit to read from stdin.
+    #[arg(trailing_var_arg = true)]
+    #[arg(name = "message", value_name = "MESSAGE")]
+    pub message: Vec<String>,
+
+    /// Pretty-print JSON output.
+    #[arg(short, long)]
+    pub pretty: bool,
+}
+
+pub fn run() {
+    let cli = Cli::parse();
+
+    let message = if stdin().is_terminal() {
+        if cli.message.is_empty() {
+            eprintln!("Failed to read message");
+            exit(1);
+        }
+
+        let path = PathBuf::from(&cli.message[0]);
+
+        if path.is_file() {
+            match fs::read_to_string(&path) {
+                Ok(message) => message,
+                Err(err) => {
+                    eprintln!("Failed to read message at {}: {err}", path.display());
+                    exit(1)
+                }
+            }
+        } else {
+            cli.message
+                .join(" ")
+                .replace('\r', "")
+                .replace('\n', "\r\n")
+        }
+    } else {
+        stdin()
+            .lock()
+            .lines()
+            .map_while(Result::ok)
+            .collect::<Vec<String>>()
+            .join("\r\n")
+    };
+
+    let Some(message) = MessageParser::default().parse(&message) else {
+        eprintln!("Failed to parse message");
+        exit(1)
+    };
+
+    let json = if cli.pretty {
+        serde_json::to_string_pretty(&message)
+    } else {
+        serde_json::to_string(&message)
+    };
+
+    match json {
+        Ok(json) => println!("{json}"),
+        Err(err) => {
+            eprintln!("Failed to parse message: {err}");
+            exit(1);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,12 @@
+#[cfg(feature = "cli")]
+mod cli;
+
+#[cfg(feature = "cli")]
+fn main() {
+    cli::run();
+}
+
+#[cfg(not(feature = "cli"))]
+fn main() {
+    eprintln!("Build with `--features cli` to enable the CLI");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
+/*
+ * SPDX-FileCopyrightText: 2020 Stalwart Labs LLC <hello@stalw.art>
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ */
+
 #[cfg(feature = "cli")]
 mod cli;
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -150,3 +150,147 @@ R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7
         "Book about ☕ tables.gif"
     );
 }
+
+#[cfg(feature = "cli")]
+mod test_cli {
+    use std::{
+        fs,
+        io::{stdin, IsTerminal, Write},
+        path::Path,
+        process::{Command, Stdio},
+    };
+
+    use serde_json::Value;
+
+    const BIN: &str = env!("CARGO_BIN_EXE_mail-parser");
+
+    fn fixture(name: &str) -> String {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("resources/eml/rfc")
+            .join(name)
+            .to_string_lossy()
+            .into_owned()
+    }
+
+    fn run_with_stdin(args: &[&str], input: Vec<u8>) -> (bool, String) {
+        let mut child = Command::new(BIN)
+            .args(args)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn process");
+
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(&input)
+            .expect("failed to write stdin");
+
+        let out = child.wait_with_output().expect("failed to wait");
+
+        let success = out.status.success();
+        let out = String::from_utf8_lossy(&out.stdout).into_owned();
+
+        (success, out)
+    }
+
+    /// Run the binary with args, inheriting the test process's stdin.
+    ///
+    /// The path and inline modes require stdin to be a terminal so
+    /// the binary can distinguish between "message provided as arg"
+    /// and "read from pipe".  Returns `None` when the test process
+    /// itself has no terminal stdin (e.g. in CI), allowing those
+    /// tests to be skipped gracefully.
+    fn run_with_tty_stdin(args: &[&str]) -> Option<(bool, String)> {
+        if !stdin().is_terminal() {
+            return None;
+        }
+
+        let out = Command::new(BIN)
+            .args(args)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .expect("failed to run process");
+
+        let success = out.status.success();
+        let out = String::from_utf8_lossy(&out.stdout).into_owned();
+
+        Some((success, out))
+    }
+
+    fn subject_of(json: &Value) -> &str {
+        json["parts"][0]["headers"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|h| h["name"] == "subject")
+            .expect("subject header not found")["value"]["Text"]
+            .as_str()
+            .unwrap()
+    }
+
+    #[test]
+    fn message_as_stdin() {
+        let eml = fs::read(fixture("001.eml")).expect("failed to read fixture");
+        let (ok, stdout) = run_with_stdin(&[], eml);
+        assert!(ok, "process did not exit successfully");
+
+        let json: Value = serde_json::from_str(&stdout).expect("stdout is not valid JSON");
+        assert_eq!(subject_of(&json), "whatever");
+    }
+
+    #[test]
+    fn message_as_path() {
+        let Some((ok, stdout)) = run_with_tty_stdin(&[&fixture("001.eml")]) else {
+            eprintln!("skipped: no terminal stdin");
+            return;
+        };
+        assert!(ok, "process did not exit successfully");
+
+        let json: Value = serde_json::from_str(&stdout).expect("stdout is not valid JSON");
+        assert_eq!(subject_of(&json), "whatever");
+    }
+
+    #[test]
+    fn inline_message() {
+        let msg = "From: Art Vandelay <art@vandelay.com>\nSubject: Inline test\n\nHello";
+        let Some((ok, stdout)) = run_with_tty_stdin(&[msg]) else {
+            eprintln!("skipped: no terminal stdin");
+            return;
+        };
+        assert!(ok, "process did not exit successfully");
+
+        let json: Value = serde_json::from_str(&stdout).expect("stdout is not valid JSON");
+        assert_eq!(subject_of(&json), "Inline test");
+    }
+
+    #[test]
+    fn pretty_flag() {
+        let eml = fs::read(fixture("001.eml")).expect("failed to read fixture");
+
+        let (ok_compact, compact) = run_with_stdin(&[], eml.clone());
+        let (ok_pretty, pretty) = run_with_stdin(&["--pretty"], eml);
+
+        assert!(ok_compact && ok_pretty, "process did not exit successfully");
+
+        assert_eq!(
+            compact.lines().count(),
+            1,
+            "compact output must be a single line"
+        );
+
+        assert!(
+            pretty.lines().count() > 1,
+            "pretty output must span multiple lines"
+        );
+
+        let a: Value = serde_json::from_str(&compact).expect("compact is not valid JSON");
+        let b: Value = serde_json::from_str(&pretty).expect("pretty is not valid JSON");
+
+        assert_eq!(a, b, "compact and pretty must represent the same data");
+    }
+}


### PR DESCRIPTION
Someone opened an issue at Himalaya CLI to parse message structure outside of protocol/backend context. Which is clearly out of scope of Himalaya CLI, so I thought it could fit well `mail-parser`. I saw many libs exposing a simple CLI behind a cargo feature. Let me know what you think about the idea. 