### PR TITLE
refactor: add no-std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ chrono = "0.4"
 
 [features]
 default = []
+std = []
 full_encoding = ["encoding_rs"]
 serde = ["dep:serde"]
 rkyv = ["dep:rkyv"]
@@ -36,3 +37,11 @@ debug = true
 
 [lib]
 doctest = false
+
+[[example]]
+name = "mailbox_iterate_maildir"
+required-features = ["std"]
+
+[[example]]
+name = "mailbox_parse_mbox"
+required-features = ["std"]

--- a/src/core/address.rs
+++ b/src/core/address.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+use alloc::{boxed::Box, vec::Vec};
+
 use crate::{Addr, Address, Group};
 
 impl<'x> Address<'x> {

--- a/src/core/header.rs
+++ b/src/core/header.rs
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use core::fmt;
-use std::hash::Hash;
-use std::net::IpAddr;
-use std::{borrow::Cow, fmt::Display};
+use alloc::{
+    borrow::Cow,
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{fmt, fmt::Display, hash::Hash, net::IpAddr};
 
 use crate::{
     Address, Attribute, ContentType, DateTime, GetHeader, Greeting, Header, HeaderName,
@@ -154,7 +157,7 @@ impl<'x> HeaderValue<'x> {
 
     pub fn as_text_list(&self) -> Option<&[Cow<'x, str>]> {
         match *self {
-            HeaderValue::Text(ref s) => Some(std::slice::from_ref(s)),
+            HeaderValue::Text(ref s) => Some(core::slice::from_ref(s)),
             HeaderValue::TextList(ref l) => Some(l.as_slice()),
             _ => None,
         }
@@ -300,7 +303,7 @@ impl PartialEq for HeaderName<'_> {
 }
 
 impl Hash for HeaderName<'_> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         match self {
             HeaderName::Other(value) => {
                 for ch in value.as_bytes() {
@@ -661,9 +664,9 @@ impl<'x> MessagePart<'x> {
         match &self.body {
             PartType::Text(text) | PartType::Html(text) => text.as_ref().into(),
             PartType::Binary(bin) | PartType::InlineBinary(bin) => {
-                std::str::from_utf8(bin.as_ref()).ok()
+                core::str::from_utf8(bin.as_ref()).ok()
             }
-            PartType::Message(message) => std::str::from_utf8(message.raw_message()).ok(),
+            PartType::Message(message) => core::str::from_utf8(message.raw_message()).ok(),
             PartType::Multipart(_) => None,
         }
     }

--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::{borrow::Cow, convert::TryInto};
+use alloc::{borrow::Cow, vec::Vec};
 
 use crate::{
     decoders::html::{html_to_text, text_to_html},
@@ -41,7 +41,7 @@ impl<'x> Message<'x> {
     /// Returns the raw header.
     pub fn header_raw(&self, header: impl Into<HeaderName<'x>>) -> Option<&str> {
         self.parts[0].headers.header(header).and_then(|h| {
-            std::str::from_utf8(&self.raw_message[h.offset_start as usize..h.offset_end as usize])
+            core::str::from_utf8(&self.raw_message[h.offset_start as usize..h.offset_end as usize])
                 .ok()
         })
     }
@@ -61,7 +61,10 @@ impl<'x> Message<'x> {
                         .get(header_.offset_start as usize..header_.offset_end as usize)
                         .map_or(HeaderValue::Empty, |bytes| match form {
                             HeaderForm::Raw => HeaderValue::Text(
-                                std::str::from_utf8(bytes).unwrap_or_default().trim().into(),
+                                core::str::from_utf8(bytes)
+                                    .unwrap_or_default()
+                                    .trim()
+                                    .into(),
                             ),
                             HeaderForm::Text => MessageStream::new(bytes).parse_unstructured(),
                             HeaderForm::Addresses => MessageStream::new(bytes).parse_address(),
@@ -104,7 +107,7 @@ impl<'x> Message<'x> {
         self.parts[0].headers.iter().filter_map(move |header| {
             Some((
                 header.name.as_str(),
-                std::str::from_utf8(
+                core::str::from_utf8(
                     &self.raw_message[header.offset_start as usize..header.offset_end as usize],
                 )
                 .ok()?,

--- a/src/core/rkyv.rs
+++ b/src/core/rkyv.rs
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::fmt::Display;
+use alloc::{boxed::Box, string::ToString};
+use core::fmt::Display;
 
 use rkyv::{string::ArchivedString, vec::ArchivedVec};
 
@@ -155,7 +156,7 @@ impl ArchivedEncoding {
 }
 
 impl Display for ArchivedHeaderName<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(self.as_str())
     }
 }
@@ -210,8 +211,8 @@ impl PartialEq for ArchivedHeaderName<'_> {
     }
 }
 
-impl std::hash::Hash for ArchivedHeaderName<'_> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl core::hash::Hash for ArchivedHeaderName<'_> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         match self {
             ArchivedHeaderName::Other(value) => {
                 for ch in value.as_bytes() {
@@ -500,7 +501,7 @@ impl<'x> ArchivedHeaderValue<'x> {
 
     pub fn as_text_list(&self) -> Option<&[ArchivedString]> {
         match *self {
-            ArchivedHeaderValue::Text(ref s) => Some(std::slice::from_ref(s)),
+            ArchivedHeaderValue::Text(ref s) => Some(core::slice::from_ref(s)),
             ArchivedHeaderValue::TextList(ref l) => Some(l.as_slice()),
             _ => None,
         }

--- a/src/decoders/base64.rs
+++ b/src/decoders/base64.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 
 use crate::parsers::MessageStream;
 

--- a/src/decoders/charsets/mod.rs
+++ b/src/decoders/charsets/mod.rs
@@ -9,6 +9,8 @@ pub mod multi_byte;
 pub mod single_byte;
 pub mod utf;
 
+use alloc::string::String;
+
 pub type DecoderFnc = fn(&[u8]) -> String;
 
 #[cfg(test)]
@@ -60,9 +62,8 @@ mod tests {
             ];
 
         for input in inputs {
-            let decoder = charset_decoder(input.0.as_bytes()).unwrap_or_else(|| {
-                panic!("{}", ("Failed to find decoder for ".to_owned() + input.0))
-            });
+            let decoder = charset_decoder(input.0.as_bytes())
+                .unwrap_or_else(|| panic!("Failed to find decoder for {}", input.0));
 
             assert_eq!(decoder(&input.1), input.2);
         }

--- a/src/decoders/charsets/multi_byte.rs
+++ b/src/decoders/charsets/multi_byte.rs
@@ -7,6 +7,8 @@
 #[cfg(feature = "full_encoding")]
 use encoding_rs::*;
 
+use alloc::string::String;
+
 #[cfg(feature = "full_encoding")]
 fn multi_byte_decoder(mut decoder: Decoder, bytes: &[u8]) -> String {
     let mut result = String::with_capacity(bytes.len() * 4);

--- a/src/decoders/charsets/single_byte.rs
+++ b/src/decoders/charsets/single_byte.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+use alloc::string::String;
+
 fn single_byte_decoder(table: &[char], bytes: &[u8]) -> String {
     let mut result = String::with_capacity(bytes.len() * 2);
 

--- a/src/decoders/charsets/utf.rs
+++ b/src/decoders/charsets/utf.rs
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::char::{decode_utf16, REPLACEMENT_CHARACTER};
+use alloc::{
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::char::{decode_utf16, REPLACEMENT_CHARACTER};
 
 use crate::decoders::base64::BASE64_MAP;
 
@@ -15,7 +19,7 @@ struct Utf7DecoderState {
 }
 
 fn add_utf16_bytes(state: &mut Utf7DecoderState, n_bytes: usize) {
-    debug_assert!(n_bytes < std::mem::size_of::<u32>());
+    debug_assert!(n_bytes < core::mem::size_of::<u32>());
 
     for byte in state.b64_bytes.to_le_bytes()[0..n_bytes].iter() {
         if let Some(pending_byte) = state.pending_byte {

--- a/src/decoders/encoded_word.rs
+++ b/src/decoders/encoded_word.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+use alloc::string::String;
+
 use crate::{decoders::charsets::map::charset_decoder, parsers::MessageStream};
 
 use super::DecodeWordFnc;

--- a/src/decoders/hex.rs
+++ b/src/decoders/hex.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+use alloc::vec::Vec;
+
 use super::quoted_printable::HEX_MAP;
 
 #[derive(PartialEq, Debug)]
@@ -76,7 +78,7 @@ mod tests {
 
             assert!(success, "Failed for '{:?}'", input.0);
 
-            let result_str = std::str::from_utf8(&result).unwrap();
+            let result_str = core::str::from_utf8(&result).unwrap();
 
             /*println!(
                 "Decoded '{}'\n -> to ->\n'{}'\n{}",

--- a/src/decoders/html.rs
+++ b/src/decoders/html.rs
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::char::REPLACEMENT_CHARACTER;
+use alloc::{string::String, vec::Vec};
+use core::char::REPLACEMENT_CHARACTER;
 
 pub fn add_html_token(result: &mut String, token: &[u8], add_space: bool) {
     if add_space {
@@ -19,7 +20,7 @@ pub fn add_html_token(result: &mut String, token: &[u8], add_space: bool) {
                 (code, 10)
             };
 
-            std::str::from_utf8(code)
+            core::str::from_utf8(code)
                 .ok()
                 .and_then(|code| u32::from_str_radix(code, radix).ok())
         } else {
@@ -32,7 +33,7 @@ pub fn add_html_token(result: &mut String, token: &[u8], add_space: bool) {
         }
     }
 
-    result.push_str(std::str::from_utf8(token).unwrap());
+    result.push_str(core::str::from_utf8(token).unwrap());
 }
 
 pub fn html_to_text(input: &str) -> String {
@@ -2358,7 +2359,11 @@ fn lookup_entity(key: &[u8]) -> Option<&u32> {
 }
 
 #[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
 mod tests {
+    use alloc::string::String;
 
     use crate::decoders::html::{add_html_token, html_to_text, text_to_html};
 

--- a/src/decoders/mod.rs
+++ b/src/decoders/mod.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 
 use crate::parsers::MessageStream;
 

--- a/src/decoders/quoted_printable.rs
+++ b/src/decoders/quoted_printable.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, vec::Vec};
 
 use crate::parsers::MessageStream;
 
@@ -283,6 +283,8 @@ pub static HEX_MAP: &[i8] = &[
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
+
     use crate::parsers::MessageStream;
 
     #[test]
@@ -402,7 +404,7 @@ mod tests {
             let (bytes_read, result) = s.decode_quoted_printable_mime(b"boundary");
             assert_ne!(bytes_read, usize::MAX);
             assert_eq!(
-                std::str::from_utf8(result.as_ref()).unwrap(),
+                core::str::from_utf8(result.as_ref()).unwrap(),
                 expected_result,
                 "Failed for {encoded_str:?}",
             );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,22 +3,29 @@
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
+#![no_std]
 #![doc = include_str!("../README.md")]
 #![deny(rust_2018_idioms)]
 #[forbid(unsafe_code)]
+#[macro_use]
+extern crate alloc;
+#[cfg(any(feature = "std", test))]
+extern crate std;
 pub mod core;
 pub mod decoders;
+#[cfg(feature = "std")]
 pub mod mailbox;
 pub mod parsers;
 
+use ::core::{hash::Hash, net::IpAddr};
+use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap, vec::Vec};
 use parsers::MessageStream;
-use std::{borrow::Cow, collections::HashMap, hash::Hash, net::IpAddr};
 
 /// RFC5322/RFC822 message parser.
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[allow(unpredictable_function_pointer_comparisons)]
 pub struct MessageParser {
-    pub(crate) header_map: HashMap<HeaderName<'static>, HdrParseFnc>,
+    pub(crate) header_map: BTreeMap<HeaderName<'static>, HdrParseFnc>,
     pub(crate) def_hdr_parse_fnc: HdrParseFnc,
 }
 

--- a/src/mailbox/maildir.rs
+++ b/src/mailbox/maildir.rs
@@ -7,6 +7,8 @@
 use std::{
     fs, io,
     path::{Path, PathBuf},
+    string::{String, ToString},
+    vec::Vec,
 };
 
 /// Maildir folder iterator
@@ -267,7 +269,7 @@ impl Message {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{path::PathBuf, string::ToString, vec::Vec};
 
     use crate::mailbox::maildir::{Flag, Message};
 

--- a/src/mailbox/mbox.rs
+++ b/src/mailbox/mbox.rs
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+use std::{
+    io::BufRead,
+    string::{String, ToString},
+    vec::Vec,
+};
+
 use crate::DateTime;
-use std::io::BufRead;
 
 /// Parses an Mbox mailbox from a `Read` stream, returning each message as a
 /// `Vec<u8>`.
@@ -206,6 +211,8 @@ impl Message {
 
 #[cfg(test)]
 mod tests {
+    use std::string::ToString;
+
     use crate::mailbox::mbox::Message;
 
     use super::MessageIterator;

--- a/src/parsers/fields/address.rs
+++ b/src/parsers/fields/address.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, string::String, vec::Vec};
 
 use crate::{parsers::MessageStream, Addr, Address, Group, HeaderValue};
 
@@ -163,17 +163,17 @@ impl<'x> AddressParser<'x> {
                         )
                         .into(),
                     ),
-                    addresses: std::mem::take(&mut self.addresses),
+                    addresses: core::mem::take(&mut self.addresses),
                 }
             } else if has_addresses && has_name {
                 Group {
                     name: self.group_name.take(),
-                    addresses: std::mem::take(&mut self.addresses),
+                    addresses: core::mem::take(&mut self.addresses),
                 }
             } else if has_addresses {
                 Group {
                     name: self.group_comment.take(),
-                    addresses: std::mem::take(&mut self.addresses),
+                    addresses: core::mem::take(&mut self.addresses),
                 }
             } else if has_name {
                 Group {
@@ -375,7 +375,7 @@ pub fn parse_address_local_part(addr: &str) -> Option<&str> {
     while let Some((pos, &ch)) = iter.next() {
         if ch == b'@' {
             return if pos > 0 && iter.next().is_some() {
-                std::str::from_utf8(addr.get(..pos)?).ok()
+                core::str::from_utf8(addr.get(..pos)?).ok()
             } else {
                 None
             };
@@ -392,7 +392,7 @@ pub fn parse_address_domain(addr: &str) -> Option<&str> {
     for (pos, &ch) in addr.iter().enumerate() {
         if ch == b'@' {
             return if pos > 0 && pos + 1 < addr.len() {
-                std::str::from_utf8(addr.get(pos + 1..)?).ok()
+                core::str::from_utf8(addr.get(pos + 1..)?).ok()
             } else {
                 None
             };
@@ -413,14 +413,14 @@ pub fn parse_address_user_part(addr: &str) -> Option<&str> {
             if pos > 0 {
                 while let Some((_, &ch)) = iter.next() {
                     if ch == b'@' && iter.next().is_some() {
-                        return std::str::from_utf8(addr.get(..pos)?).ok();
+                        return core::str::from_utf8(addr.get(..pos)?).ok();
                     }
                 }
             }
             return None;
         } else if ch == b'@' {
             return if pos > 0 && iter.next().is_some() {
-                std::str::from_utf8(addr.get(..pos)?).ok()
+                core::str::from_utf8(addr.get(..pos)?).ok()
             } else {
                 None
             };
@@ -442,7 +442,7 @@ pub fn parse_address_detail_part(addr: &str) -> Option<&str> {
             plus_pos = pos + 1;
         } else if ch == b'@' {
             if plus_pos != usize::MAX && iter.next().is_some() {
-                return std::str::from_utf8(addr.get(plus_pos..pos)?).ok();
+                return core::str::from_utf8(addr.get(plus_pos..pos)?).ok();
             } else {
                 return None;
             }

--- a/src/parsers/fields/content_type.rs
+++ b/src/parsers/fields/content_type.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, string::String, vec::Vec};
 
 use crate::{
     decoders::{charsets::map::charset_decoder, hex::decode_hex},

--- a/src/parsers/fields/date.rs
+++ b/src/parsers/fields/date.rs
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::fmt;
+use alloc::string::String;
+use core::fmt;
 
 use crate::{parsers::MessageStream, DateTime, HeaderValue};
 
@@ -236,7 +237,7 @@ impl DateTime {
 
     /// Returns the day of week where [0, 6] represents [Sun, Sat].
     pub fn day_of_week(&self) -> u8 {
-        (((self.to_timestamp_local() as f64 / 86400.0).floor() as i64 + 4).rem_euclid(7)) as u8
+        ((self.to_timestamp_local().div_euclid(86400) + 4).rem_euclid(7)) as u8
     }
 
     /// Returns the julian day
@@ -264,17 +265,17 @@ impl DateTime {
 }
 
 impl PartialOrd for DateTime {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Ord for DateTime {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         match self.to_timestamp() - other.to_timestamp() {
-            0 => std::cmp::Ordering::Equal,
-            x if x > 0 => std::cmp::Ordering::Greater,
-            _ => std::cmp::Ordering::Less,
+            0 => core::cmp::Ordering::Equal,
+            x if x > 0 => core::cmp::Ordering::Greater,
+            _ => core::cmp::Ordering::Less,
         }
     }
 }

--- a/src/parsers/fields/id.rs
+++ b/src/parsers/fields/id.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+use alloc::{string::String, vec::Vec};
+
 use crate::{parsers::MessageStream, HeaderValue};
 
 impl<'x> MessageStream<'x> {
@@ -71,8 +73,11 @@ impl<'x> MessageStream<'x> {
     }
 }
 #[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
 mod tests {
-    use std::borrow::Cow;
+    use alloc::{borrow::Cow, vec::Vec};
 
     use crate::parsers::{fields::load_tests, MessageStream};
 

--- a/src/parsers/fields/list.rs
+++ b/src/parsers/fields/list.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, string::String, vec::Vec};
 
 use crate::{parsers::MessageStream, HeaderValue};
 
@@ -114,6 +114,8 @@ impl<'x> MessageStream<'x> {
 }
 #[cfg(test)]
 mod tests {
+    use alloc::{string::String, vec::Vec};
+
     use crate::parsers::{fields::load_tests, MessageStream};
 
     #[test]

--- a/src/parsers/fields/mod.rs
+++ b/src/parsers/fields/mod.rs
@@ -15,6 +15,12 @@ pub mod thread;
 pub mod unstructured;
 
 #[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
+use alloc::{string::String, vec::Vec};
+
+#[cfg(test)]
 use serde::{Deserialize, Serialize};
 
 #[cfg(test)]

--- a/src/parsers/fields/raw.rs
+++ b/src/parsers/fields/raw.rs
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
+use alloc::string::String;
+
 use crate::{parsers::MessageStream, HeaderValue};
 
 impl<'x> MessageStream<'x> {

--- a/src/parsers/fields/received.rs
+++ b/src/parsers/fields/received.rs
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use alloc::boxed::Box;
+use core::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use crate::{
     parsers::MessageStream, DateTime, Greeting, HeaderValue, Host, Protocol, Received, TlsVersion,
@@ -91,7 +92,7 @@ enum State {
 
 impl<'x> MessageStream<'x> {
     pub fn parse_received(&mut self) -> HeaderValue<'x> {
-        //let c = print!("-> {}", std::str::from_utf8(self.data).unwrap());
+        //let c = print!("-> {}", core::str::from_utf8(self.data).unwrap());
 
         let mut tokenizer = Tokenizer::new(self).peekable();
         let mut received = Received::default();
@@ -558,7 +559,7 @@ impl<'x> Iterator for Tokenizer<'x, '_> {
             return self.next_token.take();
         }
 
-        let text = std::str::from_utf8(self.stream.bytes(start_pos..self.stream.offset() - 1))
+        let text = core::str::from_utf8(self.stream.bytes(start_pos..self.stream.offset() - 1))
             .unwrap_or_default();
 
         let token = match (

--- a/src/parsers/fields/unstructured.rs
+++ b/src/parsers/fields/unstructured.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, string::String, vec::Vec};
 
 use crate::{parsers::MessageStream, HeaderValue};
 struct UnstructuredParser<'x> {
@@ -90,6 +90,8 @@ impl<'x> MessageStream<'x> {
 
 #[cfg(test)]
 mod tests {
+    use alloc::string::String;
+
     use crate::parsers::{fields::load_tests, MessageStream};
 
     #[test]

--- a/src/parsers/header.rs
+++ b/src/parsers/header.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, string::String, vec::Vec};
 
 use crate::{Header, HeaderName, MessageParser};
 

--- a/src/parsers/message.rs
+++ b/src/parsers/message.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, string::String, vec::Vec};
 
 use crate::{
     decoders::{charsets::map::charset_decoder, DecodeFnc},
@@ -175,7 +175,7 @@ impl MessageParser {
                         };
                         //add_missing_type(&mut part_header, "text".into(), "plain".into());
                         message.parts.push(MessagePart {
-                            headers: std::mem::take(&mut part_headers),
+                            headers: core::mem::take(&mut part_headers),
                             offset_header: state.offset_header as u32,
                             offset_body: state.offset_body as u32,
                             offset_end: 0,
@@ -222,7 +222,7 @@ impl MessageParser {
                 };
                 message.attachments.push(message.parts.len() as u32);
                 message.parts.push(MessagePart {
-                    headers: std::mem::take(&mut part_headers),
+                    headers: core::mem::take(&mut part_headers),
                     encoding,
                     is_encoding_problem: false,
                     offset_header: state.offset_header as u32,
@@ -378,7 +378,7 @@ impl MessageParser {
 
             // Add part
             message.parts.push(MessagePart {
-                headers: std::mem::take(&mut part_headers),
+                headers: core::mem::take(&mut part_headers),
                 encoding,
                 is_encoding_problem,
                 body: body_part,
@@ -456,7 +456,7 @@ impl MessageParser {
                             // Add headers and substructure to parent part
                             if state.sub_part_ids.len() != 1 || state.sub_part_ids[0] != 0 {
                                 part.body =
-                                    PartType::Multipart(std::mem::take(&mut state.sub_part_ids));
+                                    PartType::Multipart(core::mem::take(&mut state.sub_part_ids));
                             }
 
                             // Restore ancestor's state
@@ -552,7 +552,11 @@ impl<'x> Message<'x> {
 }
 
 #[cfg(test)]
+extern crate std;
+
+#[cfg(test)]
 mod tests {
+    use alloc::vec::Vec;
     use std::{fs, path::PathBuf};
 
     use crate::MessageParser;

--- a/src/parsers/mime.rs
+++ b/src/parsers/mime.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::borrow::Cow;
 
 use super::MessageStream;
 

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::{iter::Peekable, ops::Range, slice::Iter};
+use core::{iter::Peekable, ops::Range, slice::Iter};
 
 pub mod fields;
 pub mod header;
@@ -36,7 +36,7 @@ impl<'x> MessageStream<'x> {
 
     #[inline(always)]
     pub fn offset(&self) -> usize {
-        std::cmp::min(self.pos, self.data.len())
+        core::cmp::min(self.pos, self.data.len())
     }
 
     #[inline(always)]

--- a/src/parsers/preview.rs
+++ b/src/parsers/preview.rs
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  */
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, string::String};
 
 use crate::decoders::html::html_to_text;
 


### PR DESCRIPTION
Just a proposition for `no_std` support. It was quite straightforward, except for 2 things:

- HashMap needed to be replaced by `BTreeMap`, not sure if this is an issue for headers or not
- Mbox and maildir code relies on `std`, is it sth exposed by the lib or just used for testing / examples?