### PR TITLE
fix: resent_cc() was returning Resent-To instead of Resent-Cc

### DIFF
--- a/src/core/message.rs
+++ b/src/core/message.rs
@@ -284,7 +284,7 @@ impl<'x> Message<'x> {
     pub fn resent_cc(&self) -> Option<&Address<'x>> {
         self.parts[0]
             .headers
-            .header_value(&HeaderName::ResentTo)
+            .header_value(&HeaderName::ResentCc)
             .and_then(|a| a.as_address())
     }
 


### PR DESCRIPTION
The method queried HeaderName::ResentTo instead of HeaderName::ResentCc, returning the wrong header value.