### PR TITLE
fix: to_timezone() stored seconds in tz_minute instead of minutes

### DIFF
--- a/src/parsers/fields/date.rs
+++ b/src/parsers/fields/date.rs
@@ -258,7 +258,7 @@ impl DateTime {
         dt.tz_before_gmt = tz < 0;
         let tz = tz.abs();
         dt.tz_hour = (tz / 3600) as u8;
-        dt.tz_minute = (tz % 3600) as u8;
+        dt.tz_minute = ((tz % 3600) / 60) as u8;
         dt
     }
 }


### PR DESCRIPTION
tz % 3600 yields remaining seconds, not minutes. For example +05:30 (19800s) produced tz_minute=8 (1800 truncated to u8) instead of 30.