### PR TITLE
fix: make forbid(unsafe_code) apply to the entire crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
  */
 #![doc = include_str!("../README.md")]
 #![deny(rust_2018_idioms)]
-#[forbid(unsafe_code)]
+#![forbid(unsafe_code)]
 pub mod core;
 pub mod decoders;
 pub mod mailbox;


### PR DESCRIPTION
The attribute was #[forbid(unsafe_code)] (outer), which only applied to the next item (mod core). Changed to #![forbid(unsafe_code)] (inner) so the compiler rejects unsafe code in all modules.